### PR TITLE
Prepare gflow v0.4.17 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Included examples of time limit usage in various scenarios
 - Added troubleshooting guide for timeout-related issues
 
+## [0.4.17] - 2026-07-24
+
+### Added
+- Added native macOS wheels for Apple Silicon (`aarch64`) and Intel (`x86_64`)
+  to the PyPI and nightly build matrices, with macOS included in the Rust test
+  matrix.
+- Added automatic Apple Silicon detection. On macOS `aarch64`, gflow exposes a
+  synthetic GPU slot and accounts host and GPU memory requests against the same
+  unified-memory pool.
+
+### Changed
+- Journal snapshots now serialize the scheduler's split job specification and
+  runtime vectors directly, reducing snapshot allocation and serialization
+  overhead. Existing snapshots using the legacy `jobs` array remain readable.
+- Scheduler state counts now use the maintained state index instead of scanning
+  every job.
+- Upgraded the MCP server to rmcp v2 and migrated its tool router while keeping
+  the existing gflow tool names, inputs, and output schemas.
+- Upgraded `compact_str` to 0.10, `mockall` to 0.15, TypeScript to 7, and the
+  `astral-sh/setup-uv` action to 8.3.2.
+
+### Compatibility
+- This is a backward-compatible patch release: CLI commands, HTTP endpoints,
+  MCP tools, and configuration formats are unchanged.
+- Existing state and journal files do not require migration. Legacy scheduler
+  snapshots are converted by the existing compatibility reader.
+
+### Known Limitations
+- Apple Silicon is represented as one logical GPU slot because per-device VRAM
+  is not exposed through NVML; memory scheduling therefore uses total system
+  unified memory and the limits declared on each job.
+- The macOS wheel and Apple Silicon paths are new in this release and must pass
+  the release candidate's macOS CI jobs before the release is tagged.
+
 ## [0.3.12] - Previous Release
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1154,7 +1154,7 @@ dependencies = [
 
 [[package]]
 name = "gflow"
-version = "0.4.16"
+version = "0.4.17"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gflow"
-version = "0.4.16"
+version = "0.4.17"
 edition = "2021"
 authors = ["PuQing <me@puqing.work>"]
 repository = "https://github.com/AndPuQing/gflow.git"

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,51 @@
+# gflow v0.4.17 Release Notes
+
+gflow v0.4.17 expands native macOS support, improves scheduler persistence
+performance, and updates the MCP implementation without changing its public
+tool contract.
+
+## Highlights
+
+### Apple Silicon scheduling
+
+On Apple Silicon, gflow now detects the platform automatically and exposes the
+integrated GPU as a logical scheduling slot. CPU and GPU memory requests are
+accounted against the same physical unified-memory pool, preventing a workload
+from reserving more combined memory than the machine provides.
+
+### Native macOS packages
+
+The release pipeline now builds PyPI wheels for both Apple Silicon
+(`aarch64-apple-darwin`) and Intel macOS (`x86_64-apple-darwin`). The Rust test
+matrix also runs on macOS 14 in addition to Linux.
+
+### Faster persistence snapshots
+
+Journal snapshots now serialize job specifications and runtime state directly,
+avoiding reconstruction of the legacy combined job representation. Older state
+and journal files remain supported and require no migration.
+
+### MCP v2
+
+The MCP server now uses rmcp v2 and its current tool-router API. Existing gflow
+MCP tool names, inputs, and output schemas are unchanged.
+
+## Compatibility
+
+v0.4.17 is intended as a drop-in patch upgrade from v0.4.16. It does not change
+CLI commands, HTTP endpoints, MCP tools, or configuration formats. Existing
+scheduler state is loaded through the backward-compatible reader.
+
+After the release is published, upgrade the PyPI package with:
+
+```bash
+python -m pip install --upgrade runqd==0.4.17
+```
+
+## Known Limitations
+
+- Apple Silicon is represented as one logical GPU because NVML does not expose
+  per-device VRAM for the integrated GPU. Scheduling uses total system unified
+  memory and the memory limits declared on each job.
+- Native macOS wheels and Apple Silicon scheduling are new release paths. The
+  release must not be tagged until the macOS CI matrix and wheel builds pass.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "runqd"
-version = "0.4.16"
+version = "0.4.17"
 description = "A lightweight, single-node job scheduler written in Rust."
 authors = [
     { name = "PuQing", email = "me@puqing.work" }


### PR DESCRIPTION
## Summary

- bump `Cargo.toml`, `pyproject.toml`, and the root `Cargo.lock` package to 0.4.17
- add a v0.4.17 changelog section covering the frozen 13-commit range from
  `v0.4.16` through `65bc820b1ab0453e9c3ba22f837e8692064bf2dc`
- add publication-ready release notes for Apple Silicon scheduling, native
  macOS wheels, faster persistence snapshots, and the rmcp v2 migration
- document backward compatibility, the lack of a data migration, and the new
  macOS path's release gate

## Related issues

W-12

## Testing

- `cargo check --workspace --all-features`
- `cargo test --locked --all-features --workspace`
  - 317 library tests passed
  - 25 integration/end-to-end tests passed
  - 17 doctests passed, 3 ignored
- `cargo fmt --all --check`
- `cargo clippy --locked --all-targets --all-features --workspace -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc --locked --no-deps --document-private-items --all-features --workspace --examples`
- focused regressions: 3 unified-memory, 23 MCP server, 2 journal, and 4
  legacy-state tests passed
- `bun install --cwd web --frozen-lockfile`
- `bun run --cwd web lint`
- `bun run --cwd web build`

Local Rust validation used rustc/cargo 1.97.1 on Linux. GitHub CI remains the
release gate for macOS tests and the new macOS wheel build paths. Cargo also
reports an upstream future-incompatibility notice for `proc-macro-error2
v2.0.1`; it does not produce a current compiler or Clippy warning.

The pre-existing Web review notes remain non-blocking: TypeScript files are
checked by `tsc` rather than ESLint, and `web/bun.lock` contains mixed registry
mirror hostnames while still passing frozen installation.

## Checklist

- [x] Version files and lockfile agree on 0.4.17.
- [x] Changelog and release notes reflect `v0.4.16..65bc820`.
- [x] Local Rust, documentation, targeted regression, and Web gates pass.
- [x] No tag, release, merge, or package publication was performed.
