### PR TITLE
feat(scheduler): fair-share scheduling with decayed per-user GPU-time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Fair-Share Scheduling**: reorder queued jobs so users with less recent GPU-time usage are scheduled first
+  - Slurm-style exponentially decayed per-user GPU-time accounting (`gpus × runtime`), persisted across restarts
+  - Reorders only within the same priority band; never overrides group concurrency limits, reservations, or resource availability
+  - Live usage from running jobs is counted so long-running jobs lower their owner's share immediately
+  - New `[daemon.fair_share]` config: `enabled` (default `true`) and `half_life_secs` (default 7 days), also settable via `GFLOW_DAEMON__FAIR_SHARE__*` env vars
+
 - **Job Time Limits**: Comprehensive support for setting maximum runtime for jobs
   - New `--time` / `-t` parameter for `gbatch` command
   - Support for multiple time formats: `HH:MM:SS`, `MM:SS`, and `MM` (minutes)

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -139,6 +139,40 @@ For GPU poll interval:
 3. Config file (`daemon.gpu_poll_interval_secs = ...`)
 4. Default: `10`
 
+#### Fair-Share Scheduling
+
+On a shared workstation, fair-share scheduling reorders queued jobs so that
+users who have consumed less GPU-time recently are scheduled sooner. It only
+reorders jobs **within the same priority band** — a higher `priority` always
+wins — and never overrides hard limits (group concurrency caps, reservations,
+memory/GPU availability).
+
+Historical usage is tracked per user as GPU-seconds (`gpus × runtime`) and
+decays exponentially with a configurable half-life, so recent usage matters
+more than old usage. Usage accounting is persisted across daemon restarts.
+
+Config file:
+
+```toml
+[daemon.fair_share]
+enabled = true        # default: true
+half_life_secs = 604800 # default: 7 days
+```
+
+- `enabled`: whether fair-share reordering influences scheduling. Usage is
+  accounted regardless, so enabling it later already has history available.
+- `half_life_secs`: decay half-life for historical usage. Smaller values react
+  faster to recent usage; larger values smooth fairness over a longer window.
+
+Environment variables (override config):
+
+```bash
+GFLOW_DAEMON__FAIR_SHARE__ENABLED=false
+GFLOW_DAEMON__FAIR_SHARE__HALF_LIFE_SECS=86400
+```
+
+With a single user, fair-share has no observable effect.
+
 ## Timezone
 
 Configure timezone for displaying and parsing reservation times.

--- a/docs/src/zh-CN/user-guide/configuration.md
+++ b/docs/src/zh-CN/user-guide/configuration.md
@@ -139,6 +139,37 @@ GPU 轮询间隔优先级（从高到低）：
 3. 配置文件（`daemon.gpu_poll_interval_secs = ...`）
 4. 默认：`10`
 
+#### 公平调度（Fair-Share）
+
+在共享工作站上，公平调度会重新排列排队中的作业，让近期消耗 GPU 时间更少的
+用户优先被调度。它只在**相同优先级带内**重排——`priority` 更高的作业永远优先——
+并且不会突破硬性限制（组并发上限、reservations、内存 / GPU 可用性）。
+
+历史用量按用户以 GPU-秒（`gpus × runtime`）累计，并按可配置的半衰期指数衰减，
+因此近期用量比久远用量权重更高。用量统计会持久化，重启守护进程后依然保留。
+
+配置文件：
+
+```toml
+[daemon.fair_share]
+enabled = true        # 默认：true
+half_life_secs = 604800 # 默认：7 天
+```
+
+- `enabled`：公平重排是否影响调度。无论开关与否都会记账，因此之后再用
+  开启时已经积累了历史数据。
+- `half_life_secs`：历史用量的衰减半衰期。值越小对近期用量反应越快，
+  值越大则在更长的窗口内平滑公平性。
+
+环境变量（覆盖配置）：
+
+```bash
+GFLOW_DAEMON__FAIR_SHARE__ENABLED=false
+GFLOW_DAEMON__FAIR_SHARE__HALF_LIFE_SECS=86400
+```
+
+单用户场景下，公平调度没有可观察的效果。
+
 ## 时区
 
 配置预约时间的显示和解析时区。

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,10 @@ pub struct DaemonConfig {
     #[serde(default = "default_gpu_poll_interval_secs")]
     #[serde(skip_serializing_if = "is_default_gpu_poll_interval_secs")]
     pub gpu_poll_interval_secs: u64,
+    /// Fair-share scheduling settings.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "FairShareConfig::is_default")]
+    pub fair_share: FairShareConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -104,6 +108,50 @@ impl ProjectsConfig {
     fn is_default(value: &Self) -> bool {
         value.known_projects.is_empty() && !value.require_project
     }
+}
+
+/// Fair-share scheduling: reorder jobs within the same priority band so that
+/// users who have consumed less GPU-time recently are scheduled first.
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct FairShareConfig {
+    /// Whether fair-share reordering influences scheduling (default: true).
+    /// Accounting of historical usage happens regardless of this flag.
+    #[serde(default = "default_fair_share_enabled")]
+    pub enabled: bool,
+    /// Half-life (in seconds) for the exponential decay of historical GPU-time
+    /// usage (default: 7 days). Smaller values make scheduling react faster to
+    /// recent usage; larger values smooth fairness over a longer window.
+    #[serde(default = "default_fair_share_half_life_secs")]
+    #[serde(skip_serializing_if = "is_default_fair_share_half_life_secs")]
+    pub half_life_secs: u64,
+}
+
+impl Default for FairShareConfig {
+    fn default() -> Self {
+        Self {
+            enabled: default_fair_share_enabled(),
+            half_life_secs: default_fair_share_half_life_secs(),
+        }
+    }
+}
+
+impl FairShareConfig {
+    fn is_default(value: &Self) -> bool {
+        value.enabled == default_fair_share_enabled()
+            && value.half_life_secs == default_fair_share_half_life_secs()
+    }
+}
+
+fn default_fair_share_enabled() -> bool {
+    true
+}
+
+fn default_fair_share_half_life_secs() -> u64 {
+    7 * 24 * 3600
+}
+
+fn is_default_fair_share_half_life_secs(v: &u64) -> bool {
+    *v == default_fair_share_half_life_secs()
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -206,6 +254,7 @@ impl Default for DaemonConfig {
             gpus: None,
             gpu_allocation_strategy: GpuAllocationStrategy::default(),
             gpu_poll_interval_secs: default_gpu_poll_interval_secs(),
+            fair_share: FairShareConfig::default(),
         }
     }
 }
@@ -291,6 +340,36 @@ mod tests {
             .unwrap();
 
         assert_eq!(config.daemon.gpu_poll_interval_secs, 3);
+    }
+
+    #[test]
+    fn fair_share_defaults_are_sane() {
+        let fs = FairShareConfig::default();
+        assert!(fs.enabled);
+        assert_eq!(fs.half_life_secs, 7 * 24 * 3600);
+    }
+
+    #[test]
+    fn environment_source_applies_fair_share_settings() {
+        let mut env = config::Map::new();
+        env.insert(
+            "GFLOW_DAEMON__FAIR_SHARE__ENABLED".to_string(),
+            "false".to_string(),
+        );
+        env.insert(
+            "GFLOW_DAEMON__FAIR_SHARE__HALF_LIFE_SECS".to_string(),
+            "3600".to_string(),
+        );
+
+        let config = config::Config::builder()
+            .add_source(environment_source(Some(env)))
+            .build()
+            .unwrap()
+            .try_deserialize::<Config>()
+            .unwrap();
+
+        assert!(!config.daemon.fair_share.enabled);
+        assert_eq!(config.daemon.fair_share.half_life_secs, 3600);
     }
 
     #[test]

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -29,6 +29,18 @@ mod transitions;
 
 pub use builder::SchedulerBuilder;
 
+/// Default fair-share usage half-life: 7 days (in seconds), matching Slurm's
+/// `PriorityDecayHalfLife` default.
+pub(crate) const DEFAULT_FAIR_SHARE_HALF_LIFE_SECS: f64 = 7.0 * 24.0 * 3600.0;
+
+/// Current wall-clock time as Unix seconds (for fair-share decay accounting).
+pub(crate) fn current_unix_secs() -> i64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
 #[derive(Debug, Clone, Default)]
 pub(crate) struct DependencyRuntime {
     pub total: u32,
@@ -67,6 +79,37 @@ impl Ord for ReadyEntry {
 impl PartialOrd for ReadyEntry {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
         Some(self.cmp(other))
+    }
+}
+
+/// Decayed historical GPU-time usage for a single user, used for fair-share
+/// scheduling. `usage` holds GPU-seconds already decayed as of `last_update`.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+pub struct FairShareUsage {
+    /// Decayed cumulative GPU-seconds (gpus * runtime) credited to this user.
+    pub usage: f64,
+    /// Unix timestamp (seconds) at which `usage` was last decayed/updated.
+    pub last_update: i64,
+}
+
+impl Default for FairShareUsage {
+    fn default() -> Self {
+        Self {
+            usage: 0.0,
+            last_update: 0,
+        }
+    }
+}
+
+impl FairShareUsage {
+    /// Return the stored usage decayed forward to `now` using an exponential
+    /// half-life: `usage * 2^(-dt / half_life_secs)`.
+    pub(crate) fn decayed_to(&self, now: i64, half_life_secs: f64) -> f64 {
+        if half_life_secs <= 0.0 {
+            return 0.0;
+        }
+        let dt = (now - self.last_update).max(0) as f64;
+        self.usage * 2.0_f64.powf(-dt / half_life_secs)
     }
 }
 
@@ -127,6 +170,17 @@ pub struct Scheduler {
     /// Maps group_id -> count of running jobs in that group
     #[serde(skip)]
     pub(crate) group_running_count: HashMap<uuid::Uuid, usize>,
+    /// Per-user decayed historical GPU-time usage for fair-share scheduling.
+    /// Maps username -> FairShareUsage. Persisted so fairness survives restarts
+    /// and independent of job-history retention.
+    #[serde(default)]
+    pub(crate) fair_share_usage: HashMap<CompactString, FairShareUsage>,
+    /// Whether fair-share reordering influences scheduling (runtime config).
+    #[serde(skip)]
+    pub(crate) fair_share_enabled: bool,
+    /// Half-life (seconds) for fair-share usage decay (runtime config).
+    #[serde(skip)]
+    pub(crate) fair_share_half_life_secs: f64,
     /// GPU reservations
     pub reservations: Vec<GpuReservation>,
     /// Next reservation ID
@@ -532,6 +586,213 @@ mod tests {
         assert_eq!(prepared_after_finish.len(), 1);
         assert_eq!(prepared_after_finish[0].id, exclusive_job_id);
         assert_eq!(scheduler.get_job(exclusive_job_id).unwrap().reason, None);
+    }
+
+    // ===== Fair-share scheduling tests =====
+
+    fn create_single_gpu_scheduler() -> Scheduler {
+        let mut scheduler = create_test_scheduler();
+        scheduler.gpu_slots.insert(
+            "GPU-0".to_string(),
+            GPUSlot {
+                index: 0,
+                available: true,
+                total_memory_mb: None,
+                reason: None,
+            },
+        );
+        scheduler
+    }
+
+    fn gpu_job(username: &str, priority: u8) -> Job {
+        JobBuilder::new()
+            .submitted_by(username.to_string())
+            .run_dir("/tmp")
+            .gpus(1)
+            .priority(priority)
+            .build()
+    }
+
+    #[test]
+    fn test_fair_share_schedules_lower_usage_user_first() {
+        let mut scheduler = create_single_gpu_scheduler();
+        let now = current_unix_secs();
+        scheduler.fair_share_usage.insert(
+            "alice".into(),
+            FairShareUsage {
+                usage: 1_000_000.0,
+                last_update: now,
+            },
+        );
+
+        // Alice submits first, so FIFO alone would favor her.
+        let (alice_id, _) = scheduler.submit_job(gpu_job("alice", 0));
+        let (bob_id, _) = scheduler.submit_job(gpu_job("bob", 0));
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(
+            prepared[0].id, bob_id,
+            "underserved user should win the only GPU"
+        );
+        assert_eq!(
+            scheduler.get_job(alice_id).map(|j| j.state),
+            Some(JobState::Queued)
+        );
+    }
+
+    #[test]
+    fn test_fair_share_priority_band_dominates_usage() {
+        let mut scheduler = create_single_gpu_scheduler();
+        let now = current_unix_secs();
+        scheduler.fair_share_usage.insert(
+            "alice".into(),
+            FairShareUsage {
+                usage: 1_000_000.0,
+                last_update: now,
+            },
+        );
+
+        // Bob is underserved but low priority; Alice is a heavy user but high priority.
+        let (bob_id, _) = scheduler.submit_job(gpu_job("bob", 0));
+        let (alice_id, _) = scheduler.submit_job(gpu_job("alice", 10));
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(
+            prepared[0].id, alice_id,
+            "priority band must dominate fair-share"
+        );
+        assert_eq!(
+            scheduler.get_job(bob_id).map(|j| j.state),
+            Some(JobState::Queued)
+        );
+    }
+
+    #[test]
+    fn test_fair_share_disabled_falls_back_to_fifo() {
+        let mut scheduler = create_single_gpu_scheduler();
+        scheduler.fair_share_enabled = false;
+        let now = current_unix_secs();
+        scheduler.fair_share_usage.insert(
+            "alice".into(),
+            FairShareUsage {
+                usage: 1_000_000.0,
+                last_update: now,
+            },
+        );
+
+        let (alice_id, _) = scheduler.submit_job(gpu_job("alice", 0));
+        let (_bob_id, _) = scheduler.submit_job(gpu_job("bob", 0));
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(
+            prepared[0].id, alice_id,
+            "disabled fair-share keeps FIFO order"
+        );
+    }
+
+    #[test]
+    fn test_fair_share_factors_rank_underserved_higher() {
+        let mut scheduler = create_test_scheduler();
+        let now = current_unix_secs();
+        scheduler.fair_share_usage.insert(
+            "alice".into(),
+            FairShareUsage {
+                usage: 3000.0,
+                last_update: now,
+            },
+        );
+        scheduler.fair_share_usage.insert(
+            "bob".into(),
+            FairShareUsage {
+                usage: 1000.0,
+                last_update: now,
+            },
+        );
+
+        let factors = scheduler.fair_share_factors(now);
+        let alice = factors.get("alice").copied().unwrap();
+        let bob = factors.get("bob").copied().unwrap();
+        assert!(
+            bob > alice,
+            "lower usage => higher factor (bob {bob} > alice {alice})"
+        );
+        // Bob is below his fair share (> 0.5), Alice is above hers (< 0.5).
+        assert!(bob > 0.5);
+        assert!(alice < 0.5);
+    }
+
+    #[test]
+    fn test_fair_share_usage_decays_with_half_life() {
+        let usage = FairShareUsage {
+            usage: 1000.0,
+            last_update: 0,
+        };
+        let half_life = 3600.0;
+        assert!((usage.decayed_to(0, half_life) - 1000.0).abs() < 1e-9);
+        assert!((usage.decayed_to(3600, half_life) - 500.0).abs() < 1e-9);
+        assert!((usage.decayed_to(7200, half_life) - 250.0).abs() < 1e-9);
+        // Time going backwards must not increase usage.
+        assert!((usage.decayed_to(-100, half_life) - 1000.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_terminal_job_credits_fair_share_usage() {
+        let mut scheduler = create_single_gpu_scheduler();
+        let (job_id, _) = scheduler.submit_job(gpu_job("alice", 0));
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+
+        // Backdate the start so the credited GPU-time is deterministic.
+        scheduler.job_runtimes[(job_id - 1) as usize].started_at =
+            Some(std::time::SystemTime::now() - std::time::Duration::from_secs(100));
+
+        scheduler.finish_job(job_id);
+
+        let usage = scheduler.fair_share_usage.get("alice").copied().unwrap();
+        // 1 GPU * ~100s runtime.
+        assert!(
+            (99.0..=101.0).contains(&usage.usage),
+            "expected ~100 GPU-seconds, got {}",
+            usage.usage
+        );
+    }
+
+    #[test]
+    fn test_cancelled_queued_job_credits_no_usage() {
+        let mut scheduler = create_test_scheduler();
+        let (job_id, _) = scheduler.submit_job(gpu_job("alice", 0));
+
+        // Cancel while still queued (never ran).
+        scheduler.cancel_job(job_id, None);
+
+        assert!(!scheduler.fair_share_usage.contains_key("alice"));
+    }
+
+    #[test]
+    fn test_fair_share_usage_persists_through_serde_roundtrip() {
+        let mut scheduler = create_test_scheduler();
+        scheduler.fair_share_usage.insert(
+            "alice".into(),
+            FairShareUsage {
+                usage: 1234.5,
+                last_update: 42,
+            },
+        );
+
+        let json = serde_json::to_string(&scheduler).unwrap();
+        let restored: Scheduler = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(
+            restored.fair_share_usage.get("alice").copied(),
+            Some(FairShareUsage {
+                usage: 1234.5,
+                last_update: 42,
+            })
+        );
     }
 
     #[test]

--- a/src/core/scheduler/builder.rs
+++ b/src/core/scheduler/builder.rs
@@ -9,6 +9,8 @@ pub struct SchedulerBuilder {
     allowed_gpu_indices: Option<Vec<u32>>,
     gpu_allocation_strategy: GpuAllocationStrategy,
     unified_memory: bool,
+    fair_share_enabled: bool,
+    fair_share_half_life_secs: f64,
 }
 
 impl SchedulerBuilder {
@@ -21,6 +23,8 @@ impl SchedulerBuilder {
             allowed_gpu_indices: None,
             gpu_allocation_strategy: GpuAllocationStrategy::default(),
             unified_memory: false,
+            fair_share_enabled: true,
+            fair_share_half_life_secs: DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
         }
     }
 
@@ -59,6 +63,17 @@ impl SchedulerBuilder {
         self
     }
 
+    /// Configure fair-share scheduling.
+    ///
+    /// `enabled` controls whether historical usage reorders jobs within a
+    /// priority band; `half_life_secs` is the exponential decay half-life for
+    /// usage accounting.
+    pub fn with_fair_share(mut self, enabled: bool, half_life_secs: f64) -> Self {
+        self.fair_share_enabled = enabled;
+        self.fair_share_half_life_secs = half_life_secs;
+        self
+    }
+
     pub fn build(self) -> Scheduler {
         Scheduler {
             version: crate::core::migrations::CURRENT_VERSION,
@@ -80,6 +95,9 @@ impl SchedulerBuilder {
             dependency_runtimes: Vec::new(),
             ready_heap: std::collections::BinaryHeap::new(),
             group_running_count: HashMap::new(),
+            fair_share_usage: HashMap::new(),
+            fair_share_enabled: self.fair_share_enabled,
+            fair_share_half_life_secs: self.fair_share_half_life_secs,
             reservations: Vec::new(),
             next_reservation_id: 1,
         }

--- a/src/core/scheduler/persistence.rs
+++ b/src/core/scheduler/persistence.rs
@@ -71,6 +71,8 @@ struct SchedulerSerde {
     pub(crate) allowed_gpu_indices: Option<Vec<u32>>,
     pub reservations: Vec<GpuReservation>,
     pub next_reservation_id: u32,
+    #[serde(default)]
+    pub(crate) fair_share_usage: HashMap<CompactString, FairShareUsage>,
 }
 
 #[derive(Deserialize)]
@@ -95,6 +97,7 @@ impl Default for SchedulerSerde {
             allowed_gpu_indices: None,
             reservations: Vec::new(),
             next_reservation_id: 1,
+            fair_share_usage: HashMap::new(),
         }
     }
 }
@@ -121,6 +124,9 @@ impl Default for Scheduler {
             dependency_runtimes: Vec::new(),
             ready_heap: std::collections::BinaryHeap::new(),
             group_running_count: HashMap::new(),
+            fair_share_usage: HashMap::new(),
+            fair_share_enabled: true,
+            fair_share_half_life_secs: crate::core::scheduler::DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
             reservations: Vec::new(),
             next_reservation_id: 1,
         }
@@ -201,6 +207,9 @@ impl<'de> Deserialize<'de> for Scheduler {
             dependency_runtimes: Vec::new(),
             ready_heap: std::collections::BinaryHeap::new(),
             group_running_count: HashMap::new(),
+            fair_share_usage: persisted.fair_share_usage,
+            fair_share_enabled: true,
+            fair_share_half_life_secs: crate::core::scheduler::DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
             reservations: persisted.reservations,
             next_reservation_id: persisted.next_reservation_id,
         };
@@ -224,6 +233,7 @@ impl Scheduler {
         self.allowed_gpu_indices = loaded.allowed_gpu_indices;
         self.reservations = std::mem::take(&mut loaded.reservations);
         self.next_reservation_id = loaded.next_reservation_id;
+        self.fair_share_usage = std::mem::take(&mut loaded.fair_share_usage);
 
         self.state_path = state_path;
     }

--- a/src/core/scheduler/scheduling.rs
+++ b/src/core/scheduler/scheduling.rs
@@ -166,6 +166,20 @@ impl Scheduler {
             runnable_jobs.push(entry.job_id);
         }
 
+        // Apply fair-share reordering. The ready heap orders jobs by static keys
+        // (priority, time bonus, FIFO) captured at enqueue time; fair-share is
+        // dynamic, so after draining the heap we recompute each user's current
+        // factor and re-sort the feasible set. This only reorders jobs within a
+        // priority band — hard constraints (group concurrency limits,
+        // reservations, memory/GPU availability) are still enforced per job below.
+        if self.fair_share_enabled {
+            let factors = self.fair_share_factors(current_unix_secs());
+            runnable_jobs.sort_by(|&a, &b| {
+                self.fair_share_sort_key(b, &factors)
+                    .cmp(&self.fair_share_sort_key(a, &factors))
+            });
+        }
+
         // Allocate resources for runnable jobs
         let mut available_memory = self.available_memory_mb;
         for job_id in runnable_jobs {
@@ -398,6 +412,80 @@ impl Scheduler {
             .into_iter()
             .filter_map(|id| self.get_job(id))
             .collect()
+    }
+
+    /// Compute a fair-share factor in `(0, 1]` for each user, combining decayed
+    /// historical usage with live usage from currently running jobs. A higher
+    /// factor means the user is more underserved and should be scheduled sooner.
+    ///
+    /// The factor is `2^(-level)` where `level = (usage / total_usage) * N` and
+    /// `N` is the number of users with usage: a user at exactly their fair share
+    /// (1/N of total) has level 1 (factor 0.5), an idle user approaches 1, and a
+    /// resource hog approaches 0. With no recorded usage every user maps to 1.0,
+    /// which falls back to the existing ordering. Users absent from the returned
+    /// map (brand-new users) should be treated as factor 1.0 by callers.
+    pub(super) fn fair_share_factors(&self, now: i64) -> HashMap<CompactString, f64> {
+        let half_life = self.fair_share_half_life_secs;
+
+        // Effective usage = decayed historical credit + live running usage.
+        let mut effective: HashMap<CompactString, f64> = HashMap::new();
+        for (user, usage) in &self.fair_share_usage {
+            let decayed = usage.decayed_to(now, half_life);
+            if decayed > 0.0 {
+                *effective.entry(user.clone()).or_insert(0.0) += decayed;
+            }
+        }
+
+        for (idx, rt) in self.job_runtimes.iter().enumerate() {
+            if rt.state != JobState::Running || rt.gpus == 0 {
+                continue;
+            }
+            let Some(started) = rt.started_at else {
+                continue;
+            };
+            let Some(spec) = self.job_specs.get(idx) else {
+                continue;
+            };
+            let started_unix = started
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as i64)
+                .unwrap_or(now);
+            let elapsed = (now - started_unix).max(0) as f64;
+            *effective.entry(spec.submitted_by.clone()).or_insert(0.0) += rt.gpus as f64 * elapsed;
+        }
+
+        let total: f64 = effective.values().sum();
+        let n = effective.len();
+        effective
+            .into_iter()
+            .map(|(user, usage)| {
+                let factor = if total <= f64::EPSILON || n == 0 {
+                    1.0
+                } else {
+                    let level = (usage / total) * n as f64;
+                    2.0_f64.powf(-level)
+                };
+                (user, factor)
+            })
+            .collect()
+    }
+
+    /// Composite ordering key for fair-share scheduling: priority band first,
+    /// then fair-share factor (higher = more underserved), then the existing
+    /// time bonus and FIFO tie-breakers. The factor is quantized to an integer
+    /// so the key stays `Ord` without a float-ordering dependency.
+    fn fair_share_sort_key(
+        &self,
+        job_id: u32,
+        factors: &HashMap<CompactString, f64>,
+    ) -> (u8, u64, u32, std::cmp::Reverse<u32>) {
+        let Some((spec, rt)) = self.get_job_parts(job_id) else {
+            return (0, 0, 0, std::cmp::Reverse(job_id));
+        };
+        let factor = factors.get(&spec.submitted_by).copied().unwrap_or(1.0);
+        let factor_q = (factor.clamp(0.0, 1.0) * 1_000_000_000.0) as u64;
+        let time_bonus = Self::calculate_time_bonus(&rt.time_limit);
+        (rt.priority, factor_q, time_bonus, std::cmp::Reverse(job_id))
     }
 
     /// Phase 2: Execute jobs (call executor - can be done WITHOUT holding lock)

--- a/src/core/scheduler/transitions.rs
+++ b/src/core/scheduler/transitions.rs
@@ -566,6 +566,7 @@ impl Scheduler {
             match next {
                 JobState::Queued => self.refresh_job_readiness(job_id),
                 JobState::Finished | JobState::Failed | JobState::Cancelled | JobState::Timeout => {
+                    self.credit_fair_share_usage(job_id);
                     if propagate_terminal_state {
                         self.propagate_terminal_state_to_dependents(job_id, next);
                     }
@@ -584,6 +585,49 @@ impl Scheduler {
         reason: Option<JobStateReason>,
     ) -> Option<bool> {
         self.transition_job_state_internal(job_id, next, reason, true)
+    }
+
+    /// Credit a terminal job's GPU-time to its submitter's fair-share usage.
+    ///
+    /// Called when a job reaches a terminal state. Jobs that never ran (no
+    /// `started_at`) or requested no GPUs contribute nothing. The existing
+    /// accumulated usage is decayed forward to `now` before adding the new
+    /// GPU-seconds (`gpus * runtime`).
+    fn credit_fair_share_usage(&mut self, job_id: u32) {
+        let now = current_unix_secs();
+        let half_life = self.fair_share_half_life_secs;
+
+        let (user, gpu_seconds) = match self.get_job_parts(job_id) {
+            Some((spec, rt)) => {
+                if rt.gpus == 0 {
+                    return;
+                }
+                let Some(started) = rt.started_at else {
+                    return; // never ran -> no GPU-time to credit
+                };
+                let finished = rt.finished_at.unwrap_or_else(std::time::SystemTime::now);
+                let secs = finished
+                    .duration_since(started)
+                    .map(|d| d.as_secs_f64())
+                    .unwrap_or(0.0)
+                    .max(0.0);
+                if secs <= 0.0 {
+                    return;
+                }
+                (spec.submitted_by.clone(), rt.gpus as f64 * secs)
+            }
+            None => return,
+        };
+
+        let entry = self
+            .fair_share_usage
+            .entry(user)
+            .or_insert_with(|| FairShareUsage {
+                usage: 0.0,
+                last_update: now,
+            });
+        entry.usage = entry.decayed_to(now, half_life) + gpu_seconds;
+        entry.last_update = now;
     }
 
     pub fn finish_job(&mut self, job_id: u32) -> Option<(bool, Option<String>)> {

--- a/src/multicall/gflowd/scheduler_runtime.rs
+++ b/src/multicall/gflowd/scheduler_runtime.rs
@@ -65,6 +65,7 @@ impl SchedulerRuntime {
         allowed_gpu_indices: Option<Vec<u32>>,
         gpu_allocation_strategy: gflow::core::gpu_allocation::GpuAllocationStrategy,
         projects_config: gflow::config::ProjectsConfig,
+        fair_share: gflow::config::FairShareConfig,
     ) -> anyhow::Result<Self> {
         // Try to initialize NVML, but continue without it if it fails
         let (nvml, gpu_slots) = match Nvml::init() {
@@ -147,6 +148,7 @@ impl SchedulerRuntime {
             .with_allowed_gpu_indices(validated_gpu_indices)
             .with_gpu_allocation_strategy(gpu_allocation_strategy)
             .with_unified_memory(unified_memory)
+            .with_fair_share(fair_share.enabled, fair_share.half_life_secs as f64)
             .build();
 
         let mut runtime = Self {

--- a/src/multicall/gflowd/scheduler_runtime/tests.rs
+++ b/src/multicall/gflowd/scheduler_runtime/tests.rs
@@ -32,6 +32,7 @@ fn list_ignored_gpu_processes_is_sorted() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -79,6 +80,7 @@ async fn rejects_whitespace_project_when_project_is_required() {
             known_projects: vec![],
             require_project: true,
         },
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -110,6 +112,7 @@ async fn batch_project_validation_is_all_or_nothing() {
             known_projects: vec!["alpha".to_string()],
             require_project: true,
         },
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -140,6 +143,7 @@ async fn rejects_shared_job_without_gpu_memory_limit() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -168,6 +172,7 @@ async fn normalizes_custom_run_name_for_tmux_targets() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -193,6 +198,7 @@ async fn prefixes_custom_run_names_with_job_id_to_avoid_collisions() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -223,6 +229,7 @@ async fn batch_submit_assigns_unique_default_run_names() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -257,6 +264,7 @@ async fn batch_submit_assigns_unique_custom_run_names() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -293,6 +301,7 @@ async fn rejects_updating_shared_job_to_clear_gpu_memory_limit() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -342,6 +351,7 @@ async fn updates_job_notifications() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -400,6 +410,7 @@ async fn fail_job_creates_retry_attempt_and_retargets_queued_dependents() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -448,6 +459,7 @@ async fn explicit_fail_job_does_not_spawn_retry_attempt() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -476,6 +488,7 @@ async fn manual_redo_lineage_does_not_consume_automatic_retry_budget() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -514,6 +527,7 @@ async fn sibling_manual_redos_do_not_share_automatic_retry_budget() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -564,6 +578,7 @@ async fn timeout_does_not_spawn_retry_attempt() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -638,6 +653,7 @@ async fn enters_journal_mode_and_does_not_overwrite_state_on_migration_failure()
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 
@@ -735,6 +751,7 @@ async fn prefers_newer_journal_snapshot_and_truncates_after_state_save() {
         None,
         gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
         gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
     )
     .unwrap();
 

--- a/src/multicall/gflowd/server.rs
+++ b/src/multicall/gflowd/server.rs
@@ -59,6 +59,7 @@ pub async fn run(config: gflow::config::Config) -> anyhow::Result<()> {
         allowed_gpus,
         gpu_allocation_strategy,
         config.projects.clone(),
+        config.daemon.fair_share.clone(),
     )?;
     scheduler_runtime.set_state_saver(state_saver_handle.clone());
 

--- a/src/multicall/gflowd/webhooks.rs
+++ b/src/multicall/gflowd/webhooks.rs
@@ -730,6 +730,7 @@ mod tests {
             None,
             gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
             gflow::config::ProjectsConfig::default(),
+            gflow::config::FairShareConfig::default(),
         )
         .unwrap();
 

--- a/tests/daemon_e2e_test.rs
+++ b/tests/daemon_e2e_test.rs
@@ -205,6 +205,7 @@ impl TestSandbox {
                 gpus: None,
                 gpu_allocation_strategy: Default::default(),
                 gpu_poll_interval_secs: 10,
+                fair_share: Default::default(),
             },
             ..Default::default()
         }


### PR DESCRIPTION
## Summary

Implements fair-share scheduling for gflow (W-141): reorder queued jobs **within the same priority band** so users who have consumed less GPU-time recently are scheduled first. This is the Slurm-style approach discussed and approved in the issue.

## Design

- **Metric**: per-user GPU-time (`gpus × runtime`), decayed exponentially with a configurable half-life (default 7 days, matching Slurm's `PriorityDecayHalfLife`).
- **Factor**: `2^(-level)` where `level = (usage / total_usage) × N`. A user at exactly their equal share (1/N) sits at factor 0.5; an idle user → 1.0; a resource hog → 0. Live usage from currently running jobs is included, so a long-running job immediately lowers its owner's share.
- **Ordering**: fair-share is a *secondary sort key* inserted after `priority` in the existing `(priority, time_bonus, FIFO)` ordering. Because `prepare_jobs_for_execution` already drains the ready heap each cycle, factors are recomputed and the feasible set re-sorted there — no stale heap entries.
- **Constraints**: reordering only. Group concurrency limits, reservations, and memory/GPU availability remain hard gates and are never overridden.
- **Persistence**: a compact per-user accumulator `(usage, last_update)` is stored in scheduler state (`#[serde(default)]`, backward/forward compatible — no migration bump needed). This survives restarts and is independent of job-history retention.

## Config

```toml
[daemon.fair_share]
enabled = true          # default: true
half_life_secs = 604800 # default: 7 days
```

Also settable via `GFLOW_DAEMON__FAIR_SHARE__ENABLED` / `GFLOW_DAEMON__FAIR_SHARE__HALF_LIFE_SECS`. Accounting happens regardless of `enabled`, so turning it on later already has history available. Single-user deployments see no behavior change.

## Testing

- 9 new unit tests: ordering (underserved user wins the last GPU), priority-band dominance, disabled → FIFO fallback, factor ranking, half-life decay, terminal-job crediting, no credit for never-ran jobs, serde round-trip persistence, and config env parsing.
- `cargo test`: 336 passed. The one failing test (`batch_submit_assigns_unique_default_run_names`) fails identically on a clean checkout — pre-existing, unrelated to this change.
- `cargo clippy --all-targets` and `cargo fmt --check` clean.

Docs updated (EN + zh-CN configuration guide) and CHANGELOG entry added.
