### PR TITLE
feat(scheduler): per-user / per-project resource quotas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-User / Per-Project Resource Quotas**: cap how much of a shared machine one user or project can occupy
+  - New `[quota]` config with `default_user` / `default_project` fallbacks plus per-name `[quota.users]` / `[quota.projects]` tables; named entries merge over defaults field-by-field
+  - Limits: `max_running_jobs` and `max_running_gpus` (enforced in the scheduling loop — over-limit jobs stay queued with reason `Quota`) and `max_queued_jobs` (enforced at submission — over-limit submissions are rejected)
+  - A job must satisfy both its user quota and its project quota; jobs without a project have no project quota
+  - Runtime management: `gctl quota list` / `gctl quota set` / `gctl quota remove`, backed by new `GET/PUT/DELETE /quotas` HTTP endpoints; overrides persist in daemon state and take precedence over `gflow.toml`
+
 - **Fair-Share Scheduling**: reorder queued jobs so users with less recent GPU-time usage are scheduled first
   - Slurm-style exponentially decayed per-user GPU-time accounting (`gpus × runtime`), persisted across restarts
   - Reorders only within the same priority band; never overrides group concurrency limits, reservations, or resource availability

--- a/docs/src/reference/gctl-reference.md
+++ b/docs/src/reference/gctl-reference.md
@@ -113,3 +113,35 @@ Cancel a reservation.
 ```bash
 gctl reserve cancel <reservation_id>
 ```
+
+### `gctl quota list`
+
+Show quota subjects (users / projects) with effective limits and current
+usage (running jobs, running GPUs, queued jobs).
+
+```bash
+gctl quota list
+```
+
+### `gctl quota set`
+
+Set (merge) runtime quota limits. Select exactly one subject with `--user`,
+`--project`, `--default-user` or `--default-project`, and provide at least one
+limit flag. Overrides are persisted in the daemon state and take precedence
+over the `[quota]` section in `gflow.toml`.
+
+```bash
+gctl quota set --user alice --max-running-gpus 4 --max-queued-jobs 50
+gctl quota set --project cv-team --max-running-gpus 8
+gctl quota set --default-user --max-running-jobs 4
+```
+
+### `gctl quota remove`
+
+Remove a runtime quota override so the subject falls back to the `gflow.toml`
+baseline.
+
+```bash
+gctl quota remove --user alice
+gctl quota remove --default-user
+```

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -222,6 +222,53 @@ gqueue --project ml-research
 gqueue --format JOBID,NAME,PROJECT,ST,TIME
 ```
 
+## Resource Quotas
+
+Quotas cap how much of the machine one user or project can occupy, so a single
+heavy user cannot starve everyone else on a shared workstation. Limits apply
+to two subjects — users (`submitted_by`) and projects (`--project`) — and a job
+must satisfy **both** its user quota and its project quota.
+
+```toml
+[quota]
+# Fallback limits for every user / project not listed below.
+# Omit a field (or the whole table) to leave that dimension unlimited.
+default_user = { max_running_jobs = 4, max_running_gpus = 2, max_queued_jobs = 50 }
+default_project = { max_running_gpus = 6 }
+
+[quota.users]
+alice = { max_running_gpus = 4 }
+
+[quota.projects]
+cv-team = { max_running_gpus = 8, max_queued_jobs = 100 }
+```
+
+Limit fields (all optional; unset = unlimited):
+
+- `max_running_jobs`: maximum concurrently running jobs.
+- `max_running_gpus`: maximum concurrently allocated GPUs. A job that would
+  push usage over the cap waits; a job requesting more GPUs than the cap will
+  never start, so size caps with that in mind.
+- `max_queued_jobs`: maximum pending (queued/held) jobs, enforced **at
+  submission** — submissions over the cap are rejected rather than queued.
+
+Named entries are merged over the matching default field-by-field: `alice`
+above keeps `default_user.max_running_jobs = 4` and `max_queued_jobs = 50`
+while overriding `max_running_gpus` to 4.
+
+When a running job hits a `max_running_*` cap, the job stays queued with reason
+`Quota` (visible via `gqueue`) and starts automatically when usage drops.
+
+Runtime overrides (persist across daemon restarts, take precedence over the
+config file):
+
+```bash
+gctl quota list                                   # usage vs. limits
+gctl quota set --user alice --max-running-gpus 4
+gctl quota set --default-user --max-queued-jobs 50
+gctl quota remove --user alice                    # fall back to gflow.toml
+```
+
 ## Notifications
 
 Use [Notifications](./notifications) when you need webhook or email delivery for job and system events.

--- a/docs/src/user-guide/multi-user.md
+++ b/docs/src/user-guide/multi-user.md
@@ -65,6 +65,24 @@ gbatch --project ml-research python train.py
 
 This makes `gqueue --project ...`, `gstats`, and notifications more useful.
 
+### Cap Usage with Quotas
+
+To keep one user or team from starving everyone else, configure per-user /
+per-project quotas:
+
+```toml
+[quota]
+default_user = { max_running_jobs = 4, max_running_gpus = 2, max_queued_jobs = 50 }
+
+[quota.projects]
+cv-team = { max_running_gpus = 8 }
+```
+
+Jobs over a running limit stay queued (reason `Quota`) and start when usage
+drops; submissions over `max_queued_jobs` are rejected. Adjust at runtime with
+`gctl quota set --user alice --max-running-gpus 4` and inspect with
+`gctl quota list`. See [Configuration](./configuration.md#resource-quotas).
+
 ### Coordinate Scarce GPUs
 
 Use runtime restrictions and reservations when you need to protect capacity:
@@ -120,6 +138,7 @@ gqueue --project ml-research
 ### Respect Shared Capacity Rules
 
 - If administrators configured required projects, always pass `--project`.
+- If administrators configured quotas, jobs over a running limit stay queued with reason `Quota`, and submissions over the queue-depth limit are rejected.
 - If GPUs are reserved for another user or restricted with `gctl set-gpus`, your job may remain queued until capacity is available.
 - Ask an administrator before using reservation commands for team-wide scheduling changes.
 

--- a/docs/src/zh-CN/reference/gctl-reference.md
+++ b/docs/src/zh-CN/reference/gctl-reference.md
@@ -113,3 +113,32 @@ gctl reserve get <reservation_id>
 ```bash
 gctl reserve cancel <reservation_id>
 ```
+
+### `gctl quota list`
+
+查看配额对象（用户 / 项目）的有效上限与当前用量（运行作业数、占用 GPU 数、排队数）。
+
+```bash
+gctl quota list
+```
+
+### `gctl quota set`
+
+设置（合并）运行时配额上限。用 `--user`、`--project`、`--default-user` 或
+`--default-project` 选择唯一一个对象，并至少提供一个上限参数。覆盖值持久化在
+daemon 状态中，优先于 `gflow.toml` 的 `[quota]` 配置。
+
+```bash
+gctl quota set --user alice --max-running-gpus 4 --max-queued-jobs 50
+gctl quota set --project cv-team --max-running-gpus 8
+gctl quota set --default-user --max-running-jobs 4
+```
+
+### `gctl quota remove`
+
+删除运行时配额覆盖，使该对象回退到 `gflow.toml` 基线。
+
+```bash
+gctl quota remove --user alice
+gctl quota remove --default-user
+```

--- a/src/client.rs
+++ b/src/client.rs
@@ -660,6 +660,77 @@ impl Client {
         Ok(updated_jobs)
     }
 
+    /// List quota subjects with effective limits and current usage.
+    pub async fn list_quotas(&self) -> anyhow::Result<serde_json::Value> {
+        let response = self
+            .client
+            .get(format!("{}/quotas", self.base_url))
+            .send()
+            .await
+            .map_err(connection_error_context)?;
+
+        if !response.status().is_success() {
+            let error_msg = Self::extract_error_message(response).await;
+            return Err(anyhow!("Failed to list quotas: {}", error_msg));
+        }
+
+        response
+            .json()
+            .await
+            .context("Failed to parse quota response")
+    }
+
+    /// Merge a runtime quota override (persisted by the daemon).
+    pub async fn set_quota(
+        &self,
+        scope: &str,
+        name: Option<&str>,
+        limits: crate::config::QuotaLimits,
+    ) -> anyhow::Result<()> {
+        let request_body = serde_json::json!({
+            "scope": scope,
+            "name": name,
+            "limits": limits,
+        });
+
+        let response = self
+            .client
+            .put(format!("{}/quotas", self.base_url))
+            .json(&request_body)
+            .send()
+            .await
+            .map_err(connection_error_context)?;
+
+        if !response.status().is_success() {
+            let error_msg = Self::extract_error_message(response).await;
+            return Err(anyhow!("Failed to set quota: {}", error_msg));
+        }
+
+        Ok(())
+    }
+
+    /// Remove a runtime quota override entry.
+    pub async fn remove_quota(&self, scope: &str, name: Option<&str>) -> anyhow::Result<()> {
+        let mut url = format!("{}/quotas?scope={}", self.base_url, scope);
+        if let Some(name) = name {
+            url.push_str(&format!("&name={}", name));
+        }
+
+        let response = self
+            .client
+            .delete(url)
+            .send()
+            .await
+            .map_err(connection_error_context)?;
+
+        if !response.status().is_success() {
+            let error_msg = Self::extract_error_message(response).await;
+            return Err(anyhow!("Failed to remove quota: {}", error_msg));
+        }
+
+        Ok(())
+    }
+
     /// Create a GPU reservation
     pub async fn create_reservation(
         &self,
@@ -828,7 +899,7 @@ mod tests {
     use crate::core::reservation::GpuSpec;
     use compact_str::CompactString;
     use std::time::SystemTime;
-    use wiremock::matchers::{method, path, query_param};
+    use wiremock::matchers::{body_json, method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
     /// Build a `Client` pointed at the given mock server.
@@ -1466,6 +1537,73 @@ mod tests {
             .await
             .expect("should set concurrency");
         assert_eq!(count, 3);
+    }
+
+    // ── quotas ─────────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn list_quotas_returns_body() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/quotas"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "quotas": [],
+                "overrides": {},
+            })))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        let body = client.list_quotas().await.expect("should list quotas");
+        assert_eq!(body["quotas"], serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn set_quota_sends_scope_name_and_limits() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path("/quotas"))
+            .and(body_json(serde_json::json!({
+                "scope": "user",
+                "name": "alice",
+                "limits": {"max_running_gpus": 4},
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({})))
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        client
+            .set_quota(
+                "user",
+                Some("alice"),
+                crate::config::QuotaLimits {
+                    max_running_gpus: Some(4),
+                    ..Default::default()
+                },
+            )
+            .await
+            .expect("should set quota");
+    }
+
+    #[tokio::test]
+    async fn remove_quota_sends_query_params() {
+        let server = MockServer::start().await;
+        Mock::given(method("DELETE"))
+            .and(path("/quotas"))
+            .and(query_param("scope", "user"))
+            .and(query_param("name", "alice"))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({"removed": true})),
+            )
+            .mount(&server)
+            .await;
+
+        let client = client_for(&server);
+        client
+            .remove_quota("user", Some("alice"))
+            .await
+            .expect("should remove quota");
     }
 
     // ── reservations ───────────────────────────────────────────────────────

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,10 @@ pub struct Config {
     #[serde(default)]
     #[serde(skip_serializing_if = "ProjectsConfig::is_default")]
     pub projects: ProjectsConfig,
+    /// Per-user / per-project resource quotas
+    #[serde(default)]
+    #[serde(skip_serializing_if = "QuotaConfig::is_empty")]
+    pub quota: QuotaConfig,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -107,6 +111,118 @@ pub struct ProjectsConfig {
 impl ProjectsConfig {
     fn is_default(value: &Self) -> bool {
         value.known_projects.is_empty() && !value.require_project
+    }
+}
+
+/// Resource limits for a single quota subject (a user, a project, or one of
+/// the two defaults). `None` fields mean "unlimited"; when both a default and
+/// a named entry apply, fields are merged with the named entry winning.
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct QuotaLimits {
+    /// Maximum number of concurrently running jobs.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_running_jobs: Option<usize>,
+    /// Maximum number of concurrently allocated GPUs.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_running_gpus: Option<u32>,
+    /// Maximum number of pending (queued/held) jobs; enforced at submission.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_queued_jobs: Option<usize>,
+}
+
+impl QuotaLimits {
+    pub fn is_empty(&self) -> bool {
+        self.max_running_jobs.is_none()
+            && self.max_running_gpus.is_none()
+            && self.max_queued_jobs.is_none()
+    }
+
+    /// Field-wise merge: `Some` fields in `other` override `self`.
+    pub fn merged_with(&self, other: &QuotaLimits) -> QuotaLimits {
+        QuotaLimits {
+            max_running_jobs: other.max_running_jobs.or(self.max_running_jobs),
+            max_running_gpus: other.max_running_gpus.or(self.max_running_gpus),
+            max_queued_jobs: other.max_queued_jobs.or(self.max_queued_jobs),
+        }
+    }
+}
+
+/// Per-user / per-project resource quotas.
+///
+/// Configured via the `[quota]` section in `gflow.toml`. Runtime overrides set
+/// through `gctl quota` are persisted in the daemon state and take precedence
+/// over the file-based baseline (merged field-wise).
+#[derive(Deserialize, Serialize, Debug, Clone, Default, PartialEq)]
+pub struct QuotaConfig {
+    /// Limits applied to every user, unless overridden in `users`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "QuotaLimits::is_empty")]
+    pub default_user: QuotaLimits,
+    /// Limits applied to every project, unless overridden in `projects`.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "QuotaLimits::is_empty")]
+    pub default_project: QuotaLimits,
+    /// Per-user limits, keyed by username.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub users: HashMap<String, QuotaLimits>,
+    /// Per-project limits, keyed by project code.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
+    pub projects: HashMap<String, QuotaLimits>,
+}
+
+impl QuotaConfig {
+    pub fn is_empty(&self) -> bool {
+        self.default_user.is_empty()
+            && self.default_project.is_empty()
+            && self.users.is_empty()
+            && self.projects.is_empty()
+    }
+
+    /// Field-wise merge: entries/fields set in `other` override `self`.
+    pub fn merged_with(&self, other: &QuotaConfig) -> QuotaConfig {
+        let mut users = self.users.clone();
+        for (name, limits) in &other.users {
+            users
+                .entry(name.clone())
+                .and_modify(|existing| *existing = existing.merged_with(limits))
+                .or_insert_with(|| limits.clone());
+        }
+        let mut projects = self.projects.clone();
+        for (name, limits) in &other.projects {
+            projects
+                .entry(name.clone())
+                .and_modify(|existing| *existing = existing.merged_with(limits))
+                .or_insert_with(|| limits.clone());
+        }
+        QuotaConfig {
+            default_user: self.default_user.merged_with(&other.default_user),
+            default_project: self.default_project.merged_with(&other.default_project),
+            users,
+            projects,
+        }
+    }
+
+    /// Effective limits for a user: `default_user` merged with `users[user]`.
+    pub fn user_limits(&self, user: &str) -> QuotaLimits {
+        match self.users.get(user) {
+            Some(limits) => self.default_user.merged_with(limits),
+            None => self.default_user.clone(),
+        }
+    }
+
+    /// Effective limits for a project: `default_project` merged with
+    /// `projects[project]`. Jobs without a project have no project quota.
+    pub fn project_limits(&self, project: Option<&str>) -> Option<QuotaLimits> {
+        let project = project?;
+        Some(match self.projects.get(project) {
+            Some(limits) => self.default_project.merged_with(limits),
+            None => self.default_project.clone(),
+        })
     }
 }
 
@@ -259,6 +375,84 @@ impl Default for DaemonConfig {
     }
 }
 
+#[test]
+fn quota_config_merges_fields_and_entries() {
+    let baseline = QuotaConfig {
+        default_user: QuotaLimits {
+            max_running_jobs: Some(4),
+            max_running_gpus: Some(2),
+            max_queued_jobs: None,
+        },
+        users: [(
+            "alice".to_string(),
+            QuotaLimits {
+                max_running_gpus: Some(4),
+                ..Default::default()
+            },
+        )]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+    let overrides = QuotaConfig {
+        default_user: QuotaLimits {
+            max_queued_jobs: Some(50),
+            ..Default::default()
+        },
+        users: [
+            (
+                "alice".to_string(),
+                QuotaLimits {
+                    max_running_jobs: Some(1),
+                    ..Default::default()
+                },
+            ),
+            (
+                "bob".to_string(),
+                QuotaLimits {
+                    max_running_gpus: Some(8),
+                    ..Default::default()
+                },
+            ),
+        ]
+        .into_iter()
+        .collect(),
+        ..Default::default()
+    };
+
+    let merged = baseline.merged_with(&overrides);
+
+    // default_user: override adds max_queued_jobs, keeps baseline fields.
+    assert_eq!(
+        merged.default_user,
+        QuotaLimits {
+            max_running_jobs: Some(4),
+            max_running_gpus: Some(2),
+            max_queued_jobs: Some(50),
+        }
+    );
+    // alice: baseline entry merged with override entry.
+    assert_eq!(
+        merged.user_limits("alice"),
+        QuotaLimits {
+            max_running_jobs: Some(1),
+            max_running_gpus: Some(4),
+            max_queued_jobs: Some(50),
+        }
+    );
+    // bob: override-only entry plus merged defaults.
+    assert_eq!(
+        merged.user_limits("bob"),
+        QuotaLimits {
+            max_running_jobs: Some(4),
+            max_running_gpus: Some(8),
+            max_queued_jobs: Some(50),
+        }
+    );
+    // Unknown user falls back to merged defaults.
+    assert_eq!(merged.user_limits("carol").max_running_gpus, Some(2));
+}
+
 pub fn load_config(config_path: Option<&PathBuf>) -> Result<Config, config::ConfigError> {
     let mut config_vec = vec![];
 
@@ -370,6 +564,50 @@ mod tests {
 
         assert!(!config.daemon.fair_share.enabled);
         assert_eq!(config.daemon.fair_share.half_life_secs, 3600);
+    }
+
+    #[test]
+    fn quota_toml_section_parses() {
+        let config = config::Config::builder()
+            .add_source(config::File::from_str(
+                r#"
+[quota]
+default_user = { max_running_jobs = 4, max_running_gpus = 2, max_queued_jobs = 50 }
+default_project = { max_running_gpus = 6 }
+
+[quota.users]
+alice = { max_running_gpus = 4 }
+
+[quota.projects]
+cv-team = { max_running_gpus = 8, max_queued_jobs = 100 }
+"#,
+                config::FileFormat::Toml,
+            ))
+            .build()
+            .unwrap()
+            .try_deserialize::<Config>()
+            .unwrap();
+
+        assert_eq!(config.quota.default_user.max_running_jobs, Some(4));
+        assert_eq!(config.quota.default_project.max_running_gpus, Some(6));
+        assert_eq!(
+            config.quota.user_limits("alice"),
+            QuotaLimits {
+                max_running_jobs: Some(4),
+                max_running_gpus: Some(4),
+                max_queued_jobs: Some(50),
+            }
+        );
+        assert_eq!(
+            config.quota.project_limits(Some("cv-team")),
+            Some(QuotaLimits {
+                max_running_jobs: None,
+                max_running_gpus: Some(8),
+                max_queued_jobs: Some(100),
+            })
+        );
+        // Jobs without a project have no project quota.
+        assert_eq!(config.quota.project_limits(None), None);
     }
 
     #[test]

--- a/src/core/job/state.rs
+++ b/src/core/job/state.rs
@@ -77,6 +77,7 @@ pub enum JobStateReason {
     WaitingForResources,
     WaitingForGpu,
     WaitingForMemory,
+    WaitingForQuota,
     CancelledByUser,
     DependencyFailed(u32),
     SystemError(CompactString),
@@ -90,6 +91,7 @@ impl fmt::Display for JobStateReason {
             JobStateReason::WaitingForResources => write!(f, "Resources"),
             JobStateReason::WaitingForGpu => write!(f, "Resources"),
             JobStateReason::WaitingForMemory => write!(f, "Resources"),
+            JobStateReason::WaitingForQuota => write!(f, "Quota"),
             JobStateReason::CancelledByUser => write!(f, "CancelledByUser"),
             JobStateReason::DependencyFailed(job_id) => {
                 write!(f, "DependencyFailed:{}", job_id)

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -6,6 +6,7 @@ pub mod info;
 pub mod job;
 pub mod macros;
 pub mod migrations;
+pub mod quota;
 pub mod reservation;
 pub mod scheduler;
 

--- a/src/core/quota.rs
+++ b/src/core/quota.rs
@@ -1,0 +1,125 @@
+//! Quota support types shared between the scheduler core and the daemon API.
+
+use compact_str::CompactString;
+use serde::{Deserialize, Serialize};
+
+use crate::config::QuotaLimits;
+
+/// Which quota bucket an override or status entry refers to.
+#[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, Hash, strum::Display)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum QuotaScope {
+    /// A named user (`submitted_by`).
+    User,
+    /// A named project.
+    Project,
+    /// The fallback limits applied to every user.
+    DefaultUser,
+    /// The fallback limits applied to every project.
+    DefaultProject,
+}
+
+impl QuotaScope {
+    /// Whether this scope addresses a named entry (vs. one of the defaults).
+    pub fn is_named(self) -> bool {
+        matches!(self, QuotaScope::User | QuotaScope::Project)
+    }
+}
+
+/// Running resource consumption of one quota subject (O(1) index value).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct QuotaUsage {
+    /// Number of currently running jobs.
+    pub jobs: usize,
+    /// Number of currently allocated GPUs.
+    pub gpus: u32,
+}
+
+impl QuotaUsage {
+    fn add(&mut self, gpus: u32) {
+        self.jobs += 1;
+        self.gpus += gpus;
+    }
+
+    fn remove(&mut self, gpus: u32) {
+        self.jobs = self.jobs.saturating_sub(1);
+        self.gpus = self.gpus.saturating_sub(gpus);
+    }
+
+    fn is_zero(&self) -> bool {
+        self.jobs == 0 && self.gpus == 0
+    }
+}
+
+/// Mutable per-subject running usage indexes used for O(1) quota checks in the
+/// scheduling loop. Rebuilt from scratch on state load; maintained incrementally
+/// on job state transitions.
+#[derive(Debug, Default)]
+pub struct QuotaUsageIndex {
+    pub users: std::collections::HashMap<CompactString, QuotaUsage>,
+    pub projects: std::collections::HashMap<CompactString, QuotaUsage>,
+}
+
+impl QuotaUsageIndex {
+    pub fn clear(&mut self) {
+        self.users.clear();
+        self.projects.clear();
+    }
+
+    pub fn record_running(
+        &mut self,
+        user: &CompactString,
+        project: Option<&CompactString>,
+        gpus: u32,
+    ) {
+        self.users.entry(user.clone()).or_default().add(gpus);
+        if let Some(project) = project {
+            self.projects.entry(project.clone()).or_default().add(gpus);
+        }
+    }
+
+    pub fn release_running(
+        &mut self,
+        user: &CompactString,
+        project: Option<&CompactString>,
+        gpus: u32,
+    ) {
+        if let Some(usage) = self.users.get_mut(user) {
+            usage.remove(gpus);
+            if usage.is_zero() {
+                self.users.remove(user);
+            }
+        }
+        if let Some(project) = project {
+            if let Some(usage) = self.projects.get_mut(project) {
+                usage.remove(gpus);
+                if usage.is_zero() {
+                    self.projects.remove(project);
+                }
+            }
+        }
+    }
+
+    pub fn user(&self, user: &str) -> QuotaUsage {
+        self.users.get(user).copied().unwrap_or_default()
+    }
+
+    pub fn project(&self, project: &str) -> QuotaUsage {
+        self.projects.get(project).copied().unwrap_or_default()
+    }
+}
+
+/// Snapshot of one quota subject: effective limits plus current usage.
+/// Returned by `Scheduler::quota_status` and served by `GET /quotas`.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct QuotaStatusEntry {
+    pub scope: QuotaScope,
+    /// Subject name; empty string for `default_user` / `default_project`.
+    pub name: String,
+    /// Effective limits (baseline merged with runtime overrides).
+    pub limits: QuotaLimits,
+    pub running_jobs: usize,
+    pub running_gpus: u32,
+    pub queued_jobs: usize,
+}

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -20,6 +20,8 @@ mod access;
 mod builder;
 #[path = "scheduler/persistence.rs"]
 mod persistence;
+#[path = "scheduler/quotas.rs"]
+mod quotas;
 #[path = "scheduler/reservations.rs"]
 mod reservations;
 #[path = "scheduler/scheduling.rs"]
@@ -170,11 +172,22 @@ pub struct Scheduler {
     /// Maps group_id -> count of running jobs in that group
     #[serde(skip)]
     pub(crate) group_running_count: HashMap<uuid::Uuid, usize>,
+    /// Per-user / per-project running usage for O(1) quota checks.
+    #[serde(skip)]
+    pub(crate) quota_usage: crate::core::quota::QuotaUsageIndex,
     /// Per-user decayed historical GPU-time usage for fair-share scheduling.
     /// Maps username -> FairShareUsage. Persisted so fairness survives restarts
     /// and independent of job-history retention.
     #[serde(default)]
     pub(crate) fair_share_usage: HashMap<CompactString, FairShareUsage>,
+    /// Quota baseline loaded from `gflow.toml` (runtime config, not persisted).
+    #[serde(skip)]
+    pub(crate) quota_baseline: crate::config::QuotaConfig,
+    /// Runtime quota overrides set via `gctl quota`. Persisted so they survive
+    /// restarts; merged over `quota_baseline` field-wise.
+    #[serde(default)]
+    #[serde(skip_serializing_if = "crate::config::QuotaConfig::is_empty")]
+    pub(crate) quota_overrides: crate::config::QuotaConfig,
     /// Whether fair-share reordering influences scheduling (runtime config).
     #[serde(skip)]
     pub(crate) fair_share_enabled: bool,
@@ -929,6 +942,302 @@ mod tests {
             .state_jobs_index
             .get(&JobState::Finished)
             .is_some_and(|v| v.contains(&job_id)));
+    }
+
+    fn quota_test_scheduler() -> Scheduler {
+        let mut scheduler = create_test_scheduler();
+        scheduler.gpu_slots.insert(
+            "GPU-0".to_string(),
+            GPUSlot {
+                index: 0,
+                available: true,
+                total_memory_mb: None,
+                reason: None,
+            },
+        );
+        scheduler.gpu_slots.insert(
+            "GPU-1".to_string(),
+            GPUSlot {
+                index: 1,
+                available: true,
+                total_memory_mb: None,
+                reason: None,
+            },
+        );
+        scheduler
+    }
+
+    #[test]
+    fn test_quota_max_running_jobs_gates_scheduling() {
+        let mut scheduler = quota_test_scheduler();
+        scheduler.set_quota_baseline(crate::config::QuotaConfig {
+            default_user: crate::config::QuotaLimits {
+                max_running_jobs: Some(1),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        let (job_a, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+        let (job_b, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].id, job_a);
+        assert_eq!(
+            scheduler.get_job(job_b).map(|j| j.state),
+            Some(JobState::Queued)
+        );
+        assert!(matches!(
+            scheduler.get_job(job_b).and_then(|j| j.reason).map(|r| *r),
+            Some(JobStateReason::WaitingForQuota)
+        ));
+        assert_eq!(scheduler.quota_user_usage("alice").jobs, 1);
+
+        // Another user is not affected by alice's quota.
+        let (job_c, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("bob")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].id, job_c);
+
+        // Finishing alice's job releases the quota slot for job_b.
+        scheduler.finish_job(job_a).unwrap();
+        assert_eq!(scheduler.quota_user_usage("alice").jobs, 0);
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].id, job_b);
+    }
+
+    #[test]
+    fn test_quota_max_running_gpus_counts_requested_gpus() {
+        let mut scheduler = quota_test_scheduler();
+        scheduler.set_quota_baseline(crate::config::QuotaConfig {
+            users: [(
+                "alice".to_string(),
+                crate::config::QuotaLimits {
+                    max_running_gpus: Some(1),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        let (job_a, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+        let (job_b, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].id, job_a);
+        assert_eq!(scheduler.quota_user_usage("alice").gpus, 1);
+        assert_eq!(
+            scheduler.get_job(job_b).map(|j| j.state),
+            Some(JobState::Queued)
+        );
+    }
+
+    #[test]
+    fn test_quota_project_limits_apply_across_users() {
+        let mut scheduler = quota_test_scheduler();
+        scheduler.set_quota_baseline(crate::config::QuotaConfig {
+            projects: [(
+                "cv-team".to_string(),
+                crate::config::QuotaLimits {
+                    max_running_jobs: Some(1),
+                    ..Default::default()
+                },
+            )]
+            .into_iter()
+            .collect(),
+            ..Default::default()
+        });
+
+        let (job_a, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .project(Some("cv-team".to_string()))
+                .build(),
+        );
+        let (job_b, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("bob")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .project(Some("cv-team".to_string()))
+                .build(),
+        );
+        // Jobs without a project are not subject to project quotas.
+        let (job_c, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("bob")
+                .run_dir("/tmp")
+                .gpus(1)
+                .shared(true)
+                .build(),
+        );
+
+        let prepared = scheduler.prepare_jobs_for_execution();
+        assert_eq!(prepared.len(), 2);
+        let prepared_ids: Vec<u32> = prepared.iter().map(|j| j.id).collect();
+        assert!(prepared_ids.contains(&job_a));
+        assert!(prepared_ids.contains(&job_c));
+        assert_eq!(
+            scheduler.get_job(job_b).map(|j| j.state),
+            Some(JobState::Queued)
+        );
+        assert_eq!(scheduler.quota_project_usage("cv-team").jobs, 1);
+    }
+
+    #[test]
+    fn test_quota_usage_index_rebuilt_from_state() {
+        let mut scheduler = quota_test_scheduler();
+        let (job_a, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .gpus(2)
+                .shared(true)
+                .project(Some("cv-team".to_string()))
+                .build(),
+        );
+        scheduler.prepare_jobs_for_execution();
+        assert_eq!(scheduler.quota_user_usage("alice").gpus, 2);
+
+        // Simulate a daemon restart: indexes are rebuilt from persisted jobs.
+        scheduler.rebuild_user_jobs_index();
+        assert_eq!(scheduler.quota_user_usage("alice").jobs, 1);
+        assert_eq!(scheduler.quota_user_usage("alice").gpus, 2);
+        assert_eq!(scheduler.quota_project_usage("cv-team").jobs, 1);
+
+        scheduler.finish_job(job_a).unwrap();
+        assert_eq!(scheduler.quota_user_usage("alice").jobs, 0);
+        assert_eq!(scheduler.quota_project_usage("cv-team").gpus, 0);
+    }
+
+    #[test]
+    fn test_quota_overrides_persist_through_serde_roundtrip() {
+        let mut scheduler = create_test_scheduler();
+        scheduler.set_quota_baseline(crate::config::QuotaConfig {
+            default_user: crate::config::QuotaLimits {
+                max_running_jobs: Some(4),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+        assert!(scheduler.merge_quota_override(
+            crate::core::quota::QuotaScope::User,
+            Some("alice"),
+            &crate::config::QuotaLimits {
+                max_running_gpus: Some(8),
+                ..Default::default()
+            }
+        ));
+        // Merging empty limits changes nothing.
+        assert!(!scheduler.merge_quota_override(
+            crate::core::quota::QuotaScope::User,
+            Some("alice"),
+            &crate::config::QuotaLimits::default()
+        ));
+
+        let json = serde_json::to_string(&scheduler).unwrap();
+        let restored: Scheduler = serde_json::from_str(&json).unwrap();
+
+        // Overrides survive; the baseline is runtime config and is not persisted.
+        assert_eq!(
+            restored.quota_overrides().users.get("alice"),
+            Some(&crate::config::QuotaLimits {
+                max_running_gpus: Some(8),
+                ..Default::default()
+            })
+        );
+        assert!(restored.quota_baseline.is_empty());
+
+        // Removing the override clears it.
+        let mut restored = restored;
+        assert!(restored.remove_quota_override(crate::core::quota::QuotaScope::User, Some("alice")));
+        assert!(restored.quota_overrides().is_empty());
+    }
+
+    #[test]
+    fn test_check_queue_quota_counts_pending_and_bias() {
+        let mut scheduler = create_test_scheduler();
+        scheduler.set_quota_baseline(crate::config::QuotaConfig {
+            default_user: crate::config::QuotaLimits {
+                max_queued_jobs: Some(2),
+                ..Default::default()
+            },
+            ..Default::default()
+        });
+
+        scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .build(),
+        );
+        scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("alice")
+                .run_dir("/tmp")
+                .build(),
+        );
+
+        let no_bias = HashMap::new();
+        let violation = scheduler.check_queue_quota("alice", None, &no_bias, &no_bias);
+        assert!(violation.is_some());
+        assert!(violation.unwrap().contains("2/2"));
+
+        // Other users are unaffected.
+        assert!(scheduler
+            .check_queue_quota("bob", None, &no_bias, &no_bias)
+            .is_none());
+
+        // Batch bias counts jobs accepted earlier in the same batch.
+        let mut bias = HashMap::new();
+        bias.insert(CompactString::from("carol"), 2);
+        assert!(scheduler
+            .check_queue_quota("carol", None, &bias, &no_bias)
+            .is_some());
     }
 
     #[test]

--- a/src/core/scheduler/builder.rs
+++ b/src/core/scheduler/builder.rs
@@ -11,6 +11,7 @@ pub struct SchedulerBuilder {
     unified_memory: bool,
     fair_share_enabled: bool,
     fair_share_half_life_secs: f64,
+    quota_baseline: crate::config::QuotaConfig,
 }
 
 impl SchedulerBuilder {
@@ -25,6 +26,7 @@ impl SchedulerBuilder {
             unified_memory: false,
             fair_share_enabled: true,
             fair_share_half_life_secs: DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
+            quota_baseline: crate::config::QuotaConfig::default(),
         }
     }
 
@@ -74,6 +76,12 @@ impl SchedulerBuilder {
         self
     }
 
+    /// Configure the quota baseline (from the `[quota]` section in `gflow.toml`).
+    pub fn with_quota_baseline(mut self, quota: crate::config::QuotaConfig) -> Self {
+        self.quota_baseline = quota;
+        self
+    }
+
     pub fn build(self) -> Scheduler {
         Scheduler {
             version: crate::core::migrations::CURRENT_VERSION,
@@ -95,9 +103,12 @@ impl SchedulerBuilder {
             dependency_runtimes: Vec::new(),
             ready_heap: std::collections::BinaryHeap::new(),
             group_running_count: HashMap::new(),
+            quota_usage: crate::core::quota::QuotaUsageIndex::default(),
             fair_share_usage: HashMap::new(),
             fair_share_enabled: self.fair_share_enabled,
             fair_share_half_life_secs: self.fair_share_half_life_secs,
+            quota_baseline: self.quota_baseline,
+            quota_overrides: crate::config::QuotaConfig::default(),
             reservations: Vec::new(),
             next_reservation_id: 1,
         }

--- a/src/core/scheduler/persistence.rs
+++ b/src/core/scheduler/persistence.rs
@@ -73,6 +73,8 @@ struct SchedulerSerde {
     pub next_reservation_id: u32,
     #[serde(default)]
     pub(crate) fair_share_usage: HashMap<CompactString, FairShareUsage>,
+    #[serde(default)]
+    pub(crate) quota_overrides: crate::config::QuotaConfig,
 }
 
 #[derive(Deserialize)]
@@ -81,7 +83,7 @@ struct SchedulerSeqV2(u32, Vec<Job>, PathBuf, u32, Option<Vec<u32>>);
 #[derive(Deserialize)]
 #[serde(untagged)]
 enum SchedulerPersisted {
-    Current(SchedulerSerde),
+    Current(Box<SchedulerSerde>),
     SeqV2(SchedulerSeqV2),
 }
 
@@ -98,6 +100,7 @@ impl Default for SchedulerSerde {
             reservations: Vec::new(),
             next_reservation_id: 1,
             fair_share_usage: HashMap::new(),
+            quota_overrides: crate::config::QuotaConfig::default(),
         }
     }
 }
@@ -127,6 +130,9 @@ impl Default for Scheduler {
             fair_share_usage: HashMap::new(),
             fair_share_enabled: true,
             fair_share_half_life_secs: crate::core::scheduler::DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
+            quota_baseline: crate::config::QuotaConfig::default(),
+            quota_overrides: crate::config::QuotaConfig::default(),
+            quota_usage: crate::core::quota::QuotaUsageIndex::default(),
             reservations: Vec::new(),
             next_reservation_id: 1,
         }
@@ -141,7 +147,7 @@ impl<'de> Deserialize<'de> for Scheduler {
         use serde::de::Error;
 
         let persisted = match SchedulerPersisted::deserialize(deserializer)? {
-            SchedulerPersisted::Current(persisted) => persisted,
+            SchedulerPersisted::Current(persisted) => *persisted,
             SchedulerPersisted::SeqV2(SchedulerSeqV2(
                 version,
                 jobs,
@@ -210,6 +216,9 @@ impl<'de> Deserialize<'de> for Scheduler {
             fair_share_usage: persisted.fair_share_usage,
             fair_share_enabled: true,
             fair_share_half_life_secs: crate::core::scheduler::DEFAULT_FAIR_SHARE_HALF_LIFE_SECS,
+            quota_baseline: crate::config::QuotaConfig::default(),
+            quota_overrides: persisted.quota_overrides,
+            quota_usage: crate::core::quota::QuotaUsageIndex::default(),
             reservations: persisted.reservations,
             next_reservation_id: persisted.next_reservation_id,
         };
@@ -234,6 +243,7 @@ impl Scheduler {
         self.reservations = std::mem::take(&mut loaded.reservations);
         self.next_reservation_id = loaded.next_reservation_id;
         self.fair_share_usage = std::mem::take(&mut loaded.fair_share_usage);
+        self.quota_overrides = std::mem::take(&mut loaded.quota_overrides);
 
         self.state_path = state_path;
     }

--- a/src/core/scheduler/quotas.rs
+++ b/src/core/scheduler/quotas.rs
@@ -1,0 +1,272 @@
+//! Quota enforcement: effective-limit resolution, O(1) running-usage gating in
+//! the scheduling loop, and queue-depth checks at submission time.
+
+use super::*;
+use crate::config::{QuotaConfig, QuotaLimits};
+use crate::core::quota::{QuotaScope, QuotaStatusEntry, QuotaUsage};
+
+impl Scheduler {
+    /// Effective quotas: `gflow.toml` baseline merged with persisted runtime
+    /// overrides (overrides win field-wise).
+    pub fn effective_quotas(&self) -> QuotaConfig {
+        self.quota_baseline.merged_with(&self.quota_overrides)
+    }
+
+    /// Replace the file-based baseline (called when the daemon starts).
+    pub fn set_quota_baseline(&mut self, quota: QuotaConfig) {
+        self.quota_baseline = quota;
+    }
+
+    /// Runtime overrides currently persisted in state.
+    pub fn quota_overrides(&self) -> &QuotaConfig {
+        &self.quota_overrides
+    }
+
+    /// Merge `limits` into the persisted override for one subject. Only `Some`
+    /// fields are written; existing fields are left untouched. Returns whether
+    /// anything changed.
+    pub fn merge_quota_override(
+        &mut self,
+        scope: QuotaScope,
+        name: Option<&str>,
+        limits: &QuotaLimits,
+    ) -> bool {
+        if limits.is_empty() {
+            return false;
+        }
+        let target = match scope {
+            QuotaScope::DefaultUser => &mut self.quota_overrides.default_user,
+            QuotaScope::DefaultProject => &mut self.quota_overrides.default_project,
+            QuotaScope::User => {
+                let Some(name) = name else { return false };
+                self.quota_overrides
+                    .users
+                    .entry(name.to_string())
+                    .or_default()
+            }
+            QuotaScope::Project => {
+                let Some(name) = name else { return false };
+                self.quota_overrides
+                    .projects
+                    .entry(name.to_string())
+                    .or_default()
+            }
+        };
+        let merged = target.merged_with(limits);
+        let changed = &merged != target;
+        *target = merged;
+        changed
+    }
+
+    /// Remove a persisted override entry (or reset a default). Returns whether
+    /// anything changed.
+    pub fn remove_quota_override(&mut self, scope: QuotaScope, name: Option<&str>) -> bool {
+        match scope {
+            QuotaScope::DefaultUser => {
+                let changed = !self.quota_overrides.default_user.is_empty();
+                self.quota_overrides.default_user = QuotaLimits::default();
+                changed
+            }
+            QuotaScope::DefaultProject => {
+                let changed = !self.quota_overrides.default_project.is_empty();
+                self.quota_overrides.default_project = QuotaLimits::default();
+                changed
+            }
+            QuotaScope::User => name
+                .and_then(|name| self.quota_overrides.users.remove(name))
+                .is_some(),
+            QuotaScope::Project => name
+                .and_then(|name| self.quota_overrides.projects.remove(name))
+                .is_some(),
+        }
+    }
+
+    /// O(1) quota gate used by the scheduling loop: would starting a job that
+    /// requests `gpus` for `user` / `project` exceed any running quota?
+    pub(crate) fn within_quota(&self, user: &str, project: Option<&str>, gpus: u32) -> bool {
+        let effective = self.effective_quotas();
+
+        let user_limits = effective.user_limits(user);
+        let user_usage = self.quota_usage.user(user);
+        if let Some(max_jobs) = user_limits.max_running_jobs {
+            if user_usage.jobs >= max_jobs {
+                return false;
+            }
+        }
+        if let Some(max_gpus) = user_limits.max_running_gpus {
+            if user_usage.gpus + gpus > max_gpus {
+                return false;
+            }
+        }
+
+        if let Some(project_limits) = effective.project_limits(project) {
+            // `project` is `Some` whenever `project_limits` is `Some`.
+            let project_usage = project
+                .map(|p| self.quota_usage.project(p))
+                .unwrap_or_default();
+            if let Some(max_jobs) = project_limits.max_running_jobs {
+                if project_usage.jobs >= max_jobs {
+                    return false;
+                }
+            }
+            if let Some(max_gpus) = project_limits.max_running_gpus {
+                if project_usage.gpus + gpus > max_gpus {
+                    return false;
+                }
+            }
+        }
+
+        true
+    }
+
+    /// Count pending (Queued or Hold) jobs for a user via the user index.
+    pub fn count_pending_jobs_for_user(&self, user: &str) -> usize {
+        self.count_pending(self.user_jobs_index.get(user))
+    }
+
+    /// Count pending (Queued or Hold) jobs for a project via the project index.
+    pub fn count_pending_jobs_for_project(&self, project: &str) -> usize {
+        self.count_pending(self.project_jobs_index.get(project))
+    }
+
+    fn count_pending(&self, job_ids: Option<&Vec<u32>>) -> usize {
+        let Some(job_ids) = job_ids else {
+            return 0;
+        };
+        job_ids
+            .iter()
+            .filter_map(|&id| self.get_job_runtime(id))
+            .filter(|rt| matches!(rt.state, JobState::Queued | JobState::Hold))
+            .count()
+    }
+
+    /// Submission-time queue-depth gate. `pending_bias` carries jobs accepted
+    /// earlier in the same batch that are not indexed yet. Returns a
+    /// human-readable rejection reason, or `None` if the job may be queued.
+    pub fn check_queue_quota(
+        &self,
+        user: &str,
+        project: Option<&str>,
+        pending_bias: &HashMap<CompactString, usize>,
+        project_pending_bias: &HashMap<CompactString, usize>,
+    ) -> Option<String> {
+        let effective = self.effective_quotas();
+        let bias_key = CompactString::from(user);
+
+        let user_limits = effective.user_limits(user);
+        if let Some(max_queued) = user_limits.max_queued_jobs {
+            let pending = self.count_pending_jobs_for_user(user)
+                + pending_bias.get(&bias_key).copied().unwrap_or(0);
+            if pending >= max_queued {
+                return Some(format!(
+                    "quota exceeded for user '{user}': {pending}/{max_queued} queued jobs"
+                ));
+            }
+        }
+
+        if let (Some(project), Some(project_limits)) = (project, effective.project_limits(project))
+        {
+            if let Some(max_queued) = project_limits.max_queued_jobs {
+                let project_key = CompactString::from(project);
+                let pending = self.count_pending_jobs_for_project(project)
+                    + project_pending_bias.get(&project_key).copied().unwrap_or(0);
+                if pending >= max_queued {
+                    return Some(format!(
+                        "quota exceeded for project '{project}': {pending}/{max_queued} queued jobs"
+                    ));
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Snapshot of every quota subject that has limits configured or non-zero
+    /// usage, for `gctl quota list` / `GET /quotas`.
+    pub fn quota_status(&self) -> Vec<QuotaStatusEntry> {
+        let effective = self.effective_quotas();
+        let mut entries: Vec<QuotaStatusEntry> = Vec::new();
+
+        // Users: configured entries plus users with live usage or pending jobs.
+        let mut users: std::collections::BTreeSet<String> = effective
+            .users
+            .keys()
+            .cloned()
+            .chain(self.quota_usage.users.keys().map(|s| s.to_string()))
+            .chain(self.user_jobs_index.keys().map(|s| s.to_string()))
+            .collect();
+        // Keep output deterministic and compact: drop users that are neither
+        // configured nor currently active.
+        users.retain(|user| {
+            effective.users.contains_key(user)
+                || self.quota_usage.users.contains_key(user.as_str())
+                || self.count_pending_jobs_for_user(user) > 0
+        });
+        for user in users {
+            let usage = self.quota_usage.user(&user);
+            entries.push(QuotaStatusEntry {
+                scope: QuotaScope::User,
+                name: user.clone(),
+                limits: effective.user_limits(&user),
+                running_jobs: usage.jobs,
+                running_gpus: usage.gpus,
+                queued_jobs: self.count_pending_jobs_for_user(&user),
+            });
+        }
+
+        // Projects: same treatment.
+        let mut projects: std::collections::BTreeSet<String> = effective
+            .projects
+            .keys()
+            .cloned()
+            .chain(self.quota_usage.projects.keys().map(|s| s.to_string()))
+            .chain(self.project_jobs_index.keys().map(|s| s.to_string()))
+            .collect();
+        projects.retain(|project| {
+            effective.projects.contains_key(project)
+                || self.quota_usage.projects.contains_key(project.as_str())
+                || self.count_pending_jobs_for_project(project) > 0
+        });
+        for project in projects {
+            let usage = self.quota_usage.project(&project);
+            entries.push(QuotaStatusEntry {
+                scope: QuotaScope::Project,
+                name: project.clone(),
+                limits: effective.project_limits(Some(&project)).unwrap_or_default(),
+                running_jobs: usage.jobs,
+                running_gpus: usage.gpus,
+                queued_jobs: self.count_pending_jobs_for_project(&project),
+            });
+        }
+
+        // Defaults always reported so operators can see the fallback limits.
+        entries.push(QuotaStatusEntry {
+            scope: QuotaScope::DefaultUser,
+            name: String::new(),
+            limits: effective.default_user.clone(),
+            running_jobs: 0,
+            running_gpus: 0,
+            queued_jobs: 0,
+        });
+        entries.push(QuotaStatusEntry {
+            scope: QuotaScope::DefaultProject,
+            name: String::new(),
+            limits: effective.default_project.clone(),
+            running_jobs: 0,
+            running_gpus: 0,
+            queued_jobs: 0,
+        });
+
+        entries
+    }
+
+    /// Current running usage for a user (for tests / diagnostics).
+    pub fn quota_user_usage(&self, user: &str) -> QuotaUsage {
+        self.quota_usage.user(user)
+    }
+
+    /// Current running usage for a project (for tests / diagnostics).
+    pub fn quota_project_usage(&self, project: &str) -> QuotaUsage {
+        self.quota_usage.project(project)
+    }
+}

--- a/src/core/scheduler/scheduling.rs
+++ b/src/core/scheduler/scheduling.rs
@@ -191,6 +191,7 @@ impl Scheduler {
             let (
                 has_enough_memory,
                 within_group_limit,
+                within_quota,
                 respects_reservations,
                 required_memory,
                 job_user,
@@ -243,9 +244,22 @@ impl Scheduler {
                     true // Not part of a group
                 };
 
+                // Check per-user / per-project quotas using O(1) usage indexes
+                let job_project = self.job_specs.get(idx).and_then(|s| s.project.clone());
+                let within_quota = self.within_quota(&job_user, job_project.as_deref(), rt.gpus);
+                if !within_quota {
+                    tracing::debug!(
+                        "Job {} waiting: user/project quota reached (user: {}, project: {:?})",
+                        rt.id,
+                        job_user,
+                        job_project
+                    );
+                }
+
                 (
                     has_enough_memory,
                     within_group_limit,
+                    within_quota,
                     respects_reservations,
                     required_memory,
                     job_user,
@@ -258,7 +272,7 @@ impl Scheduler {
             };
 
             // Now allocate resources if all checks pass
-            if has_enough_memory && within_group_limit && respects_reservations {
+            if has_enough_memory && within_group_limit && within_quota && respects_reservations {
                 // Filter out GPUs that are reserved by other users
                 let mut usable_gpus = self.filter_usable_gpus(&job_user, &available_gpus);
                 self.reorder_usable_gpus(job_id, &mut usable_gpus);
@@ -392,6 +406,9 @@ impl Scheduler {
                 }
             } else if !within_group_limit {
                 self.set_job_reason(job_id, Some(JobStateReason::WaitingForResources));
+                self.enqueue_if_ready(job_id);
+            } else if !within_quota {
+                self.set_job_reason(job_id, Some(JobStateReason::WaitingForQuota));
                 self.enqueue_if_ready(job_id);
             } else if !respects_reservations {
                 self.set_job_reason(job_id, Some(JobStateReason::WaitingForGpu));
@@ -618,6 +635,7 @@ impl Scheduler {
         self.dependency_runtimes = vec![DependencyRuntime::default(); self.job_specs.len()];
         self.ready_heap.clear();
         self.group_running_count.clear();
+        self.quota_usage.clear();
 
         self.check_invariant();
 
@@ -649,6 +667,9 @@ impl Scheduler {
                 if let Some(group_id) = rt.group_id {
                     *self.group_running_count.entry(group_id).or_insert(0) += 1;
                 }
+                // Rebuild quota usage index.
+                self.quota_usage
+                    .record_running(&spec.submitted_by, spec.project.as_ref(), rt.gpus);
             }
         }
 

--- a/src/core/scheduler/transitions.rs
+++ b/src/core/scheduler/transitions.rs
@@ -560,6 +560,7 @@ impl Scheduler {
 
         if transitioned {
             self.update_group_running_count(group_id, old_state, next);
+            self.update_quota_running_usage(job_id, old_state, next);
             self.update_state_jobs_index(job_id, old_state, next);
             self.bump_ready_epoch(job_id);
 
@@ -585,6 +586,37 @@ impl Scheduler {
         reason: Option<JobStateReason>,
     ) -> Option<bool> {
         self.transition_job_state_internal(job_id, next, reason, true)
+    }
+
+    /// Maintain the per-user / per-project running usage index used for O(1)
+    /// quota checks in the scheduling loop. Mirrors `update_group_running_count`.
+    fn update_quota_running_usage(
+        &mut self,
+        job_id: u32,
+        old_state: JobState,
+        new_state: JobState,
+    ) {
+        let entering_running = new_state == JobState::Running && old_state != JobState::Running;
+        let leaving_running = old_state == JobState::Running && new_state != JobState::Running;
+
+        if !entering_running && !leaving_running {
+            return;
+        }
+
+        let Some((spec, rt)) = self.get_job_parts(job_id) else {
+            return;
+        };
+        let user = spec.submitted_by.clone();
+        let project = spec.project.clone();
+        let gpus = rt.gpus;
+
+        if entering_running {
+            self.quota_usage
+                .record_running(&user, project.as_ref(), gpus);
+        } else {
+            self.quota_usage
+                .release_running(&user, project.as_ref(), gpus);
+        }
     }
 
     /// Credit a terminal job's GPU-time to its submitter's fair-share usage.

--- a/src/multicall/gctl/cli.rs
+++ b/src/multicall/gctl/cli.rs
@@ -50,6 +50,12 @@ pub enum Commands {
         command: ReserveCommands,
     },
 
+    /// Manage per-user / per-project resource quotas
+    Quota {
+        #[command(subcommand)]
+        command: QuotaCommands,
+    },
+
     /// Generate shell completion scripts
     Completion {
         /// The shell to generate completions for
@@ -82,6 +88,55 @@ pub enum GpuProcessCommands {
 
     /// List active runtime ignore overrides
     List,
+}
+
+#[derive(Debug, Parser)]
+pub enum QuotaCommands {
+    /// Show quota subjects with effective limits and current usage
+    List,
+
+    /// Set (merge) runtime quota limits; persisted across daemon restarts.
+    /// Select exactly one subject: --user, --project, --default-user or
+    /// --default-project. Provide at least one --max-* flag.
+    Set {
+        /// Username
+        #[arg(long, group = "subject")]
+        user: Option<String>,
+        /// Project code
+        #[arg(long, group = "subject")]
+        project: Option<String>,
+        /// Apply to the fallback limits for all users
+        #[arg(long, group = "subject")]
+        default_user: bool,
+        /// Apply to the fallback limits for all projects
+        #[arg(long, group = "subject")]
+        default_project: bool,
+        /// Max concurrently running jobs
+        #[arg(long)]
+        max_running_jobs: Option<usize>,
+        /// Max concurrently allocated GPUs
+        #[arg(long)]
+        max_running_gpus: Option<u32>,
+        /// Max pending jobs (enforced at submission)
+        #[arg(long)]
+        max_queued_jobs: Option<usize>,
+    },
+
+    /// Remove a runtime quota override (falls back to gflow.toml baseline)
+    Remove {
+        /// Username
+        #[arg(long, group = "subject")]
+        user: Option<String>,
+        /// Project code
+        #[arg(long, group = "subject")]
+        project: Option<String>,
+        /// Reset the fallback limits for all users
+        #[arg(long, group = "subject")]
+        default_user: bool,
+        /// Reset the fallback limits for all projects
+        #[arg(long, group = "subject")]
+        default_project: bool,
+    },
 }
 
 #[derive(Debug, Parser)]

--- a/src/multicall/gctl/commands/mod.rs
+++ b/src/multicall/gctl/commands/mod.rs
@@ -4,6 +4,7 @@ use gflow::client::Client;
 use gflow::config::Config;
 
 pub mod gpu_process;
+pub mod quota;
 pub mod reserve_cancel;
 pub mod reserve_create;
 pub mod reserve_get;
@@ -96,6 +97,41 @@ pub async fn handle_commands(
             }
             cli::ReserveCommands::Cancel { id } => {
                 reserve_cancel::handle_reserve_cancel(client, id).await?;
+            }
+        },
+        cli::Commands::Quota { command } => match command {
+            cli::QuotaCommands::List => {
+                quota::handle_quota_list(client).await?;
+            }
+            cli::QuotaCommands::Set {
+                user,
+                project,
+                default_user,
+                default_project,
+                max_running_jobs,
+                max_running_gpus,
+                max_queued_jobs,
+            } => {
+                quota::handle_quota_set(
+                    client,
+                    user,
+                    project,
+                    default_user,
+                    default_project,
+                    max_running_jobs,
+                    max_running_gpus,
+                    max_queued_jobs,
+                )
+                .await?;
+            }
+            cli::QuotaCommands::Remove {
+                user,
+                project,
+                default_user,
+                default_project,
+            } => {
+                quota::handle_quota_remove(client, user, project, default_user, default_project)
+                    .await?;
             }
         },
         cli::Commands::Completion { shell } => {

--- a/src/multicall/gctl/commands/quota.rs
+++ b/src/multicall/gctl/commands/quota.rs
@@ -1,0 +1,157 @@
+use anyhow::{bail, Result};
+use gflow::client::Client;
+use gflow::config::QuotaLimits;
+
+/// Resolve the `(scope, name)` pair from the mutually exclusive subject flags.
+fn resolve_subject(
+    user: Option<&str>,
+    project: Option<&str>,
+    default_user: bool,
+    default_project: bool,
+) -> Result<(&'static str, Option<String>)> {
+    match (user, project, default_user, default_project) {
+        (Some(user), None, false, false) => Ok(("user", Some(user.to_string()))),
+        (None, Some(project), false, false) => Ok(("project", Some(project.to_string()))),
+        (None, None, true, false) => Ok(("default_user", None)),
+        (None, None, false, true) => Ok(("default_project", None)),
+        _ => bail!(
+            "select exactly one subject: --user, --project, --default-user or --default-project"
+        ),
+    }
+}
+
+pub async fn handle_quota_list(client: &Client) -> Result<()> {
+    let body = client.list_quotas().await?;
+
+    let Some(quotas) = body.get("quotas").and_then(|v| v.as_array()) else {
+        bail!("unexpected response format from daemon");
+    };
+
+    if quotas.is_empty() {
+        println!("No quota subjects (no limits configured, no active jobs).");
+        return Ok(());
+    }
+
+    println!(
+        "{:<14} {:<16} {:>8} {:>8} {:>7}  LIMITS",
+        "SCOPE", "NAME", "RUNNING", "GPUS", "QUEUED"
+    );
+    for entry in quotas {
+        let scope = entry.get("scope").and_then(|v| v.as_str()).unwrap_or("?");
+        let name = entry.get("name").and_then(|v| v.as_str()).unwrap_or("");
+        let running_jobs = entry
+            .get("running_jobs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let running_gpus = entry
+            .get("running_gpus")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        let queued_jobs = entry
+            .get("queued_jobs")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+
+        let mut limits: Vec<String> = Vec::new();
+        if let Some(limits_obj) = entry.get("limits") {
+            for (key, label) in [
+                ("max_running_jobs", "jobs"),
+                ("max_running_gpus", "gpus"),
+                ("max_queued_jobs", "queued"),
+            ] {
+                if let Some(value) = limits_obj.get(key).and_then(|v| v.as_u64()) {
+                    limits.push(format!("{label}<={value}"));
+                }
+            }
+        }
+        let limits_str = if limits.is_empty() {
+            "-".to_string()
+        } else {
+            limits.join(" ")
+        };
+
+        let display_name = if name.is_empty() { "-" } else { name };
+        println!(
+            "{:<14} {:<16} {:>8} {:>8} {:>7}  {}",
+            scope, display_name, running_jobs, running_gpus, queued_jobs, limits_str
+        );
+    }
+
+    Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+pub async fn handle_quota_set(
+    client: &Client,
+    user: Option<String>,
+    project: Option<String>,
+    default_user: bool,
+    default_project: bool,
+    max_running_jobs: Option<usize>,
+    max_running_gpus: Option<u32>,
+    max_queued_jobs: Option<usize>,
+) -> Result<()> {
+    let (scope, name) = resolve_subject(
+        user.as_deref(),
+        project.as_deref(),
+        default_user,
+        default_project,
+    )?;
+
+    let limits = QuotaLimits {
+        max_running_jobs,
+        max_running_gpus,
+        max_queued_jobs,
+    };
+    if limits.is_empty() {
+        bail!("provide at least one of --max-running-jobs, --max-running-gpus, --max-queued-jobs");
+    }
+
+    client.set_quota(scope, name.as_deref(), limits).await?;
+
+    println!(
+        "Updated {} quota{}",
+        scope,
+        name.as_deref()
+            .map(|n| format!(" '{n}'"))
+            .unwrap_or_default()
+    );
+    if let Some(v) = max_running_jobs {
+        println!("  max_running_jobs = {v}");
+    }
+    if let Some(v) = max_running_gpus {
+        println!("  max_running_gpus = {v}");
+    }
+    if let Some(v) = max_queued_jobs {
+        println!("  max_queued_jobs  = {v}");
+    }
+
+    Ok(())
+}
+
+pub async fn handle_quota_remove(
+    client: &Client,
+    user: Option<String>,
+    project: Option<String>,
+    default_user: bool,
+    default_project: bool,
+) -> Result<()> {
+    let (scope, name) = resolve_subject(
+        user.as_deref(),
+        project.as_deref(),
+        default_user,
+        default_project,
+    )?;
+
+    client.remove_quota(scope, name.as_deref()).await?;
+
+    println!(
+        "Removed {} quota override{}",
+        scope,
+        name.as_deref()
+            .map(|n| format!(" '{n}'"))
+            .unwrap_or_default()
+    );
+
+    Ok(())
+}

--- a/src/multicall/gctl/commands/quota.rs
+++ b/src/multicall/gctl/commands/quota.rs
@@ -33,8 +33,8 @@ pub async fn handle_quota_list(client: &Client) -> Result<()> {
     }
 
     println!(
-        "{:<14} {:<16} {:>8} {:>8} {:>7}  LIMITS",
-        "SCOPE", "NAME", "RUNNING", "GPUS", "QUEUED"
+        "{:<15} {:<16} {:>9} {:>9} {:>9}",
+        "SCOPE", "NAME", "JOBS", "GPUS", "QUEUED"
     );
     for entry in quotas {
         let scope = entry.get("scope").and_then(|v| v.as_str()).unwrap_or("?");
@@ -52,32 +52,58 @@ pub async fn handle_quota_list(client: &Client) -> Result<()> {
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
 
-        let mut limits: Vec<String> = Vec::new();
-        if let Some(limits_obj) = entry.get("limits") {
-            for (key, label) in [
-                ("max_running_jobs", "jobs"),
-                ("max_running_gpus", "gpus"),
-                ("max_queued_jobs", "queued"),
-            ] {
-                if let Some(value) = limits_obj.get(key).and_then(|v| v.as_u64()) {
-                    limits.push(format!("{label}<={value}"));
-                }
-            }
-        }
-        let limits_str = if limits.is_empty() {
-            "-".to_string()
+        let limits = entry.get("limits");
+        let max_jobs = limit_value(limits, "max_running_jobs");
+        let max_gpus = limit_value(limits, "max_running_gpus");
+        let max_queued = limit_value(limits, "max_queued_jobs");
+
+        // Fallback rows (default_user / default_project) describe limits that
+        // apply to everyone, so there is no single usage number to show —
+        // render the bare limit. Named subjects render `used/limit`.
+        let is_default = matches!(scope, "default_user" | "default_project");
+        let (jobs_col, gpus_col, queued_col) = if is_default {
+            (
+                fmt_limit(max_jobs),
+                fmt_limit(max_gpus),
+                fmt_limit(max_queued),
+            )
         } else {
-            limits.join(" ")
+            (
+                fmt_usage(running_jobs, max_jobs),
+                fmt_usage(running_gpus, max_gpus),
+                fmt_usage(queued_jobs, max_queued),
+            )
         };
 
-        let display_name = if name.is_empty() { "-" } else { name };
+        let display_name = if name.is_empty() { "*" } else { name };
         println!(
-            "{:<14} {:<16} {:>8} {:>8} {:>7}  {}",
-            scope, display_name, running_jobs, running_gpus, queued_jobs, limits_str
+            "{:<15} {:<16} {:>9} {:>9} {:>9}",
+            scope, display_name, jobs_col, gpus_col, queued_col
         );
     }
 
+    println!();
+    println!("Cells are used/limit; `-` means unlimited. Fallback rows show the limit only.");
+
     Ok(())
+}
+
+/// Extract a numeric limit field, or `None` when unset (unlimited).
+fn limit_value(limits: Option<&serde_json::Value>, key: &str) -> Option<u64> {
+    limits.and_then(|l| l.get(key)).and_then(|v| v.as_u64())
+}
+
+/// Render a limit value: the number, or `-` when unlimited.
+fn fmt_limit(limit: Option<u64>) -> String {
+    match limit {
+        Some(v) => v.to_string(),
+        None => "-".to_string(),
+    }
+}
+
+/// Render a `used/limit` cell, e.g. `3/4` or `0/-` (unlimited).
+fn fmt_usage(used: u64, limit: Option<u64>) -> String {
+    format!("{}/{}", used, fmt_limit(limit))
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/src/multicall/gflowd/scheduler_runtime.rs
+++ b/src/multicall/gflowd/scheduler_runtime.rs
@@ -265,6 +265,50 @@ impl SchedulerRuntime {
         self.mark_dirty();
     }
 
+    // ===== Quota methods =====
+
+    /// Set the file-based quota baseline (from `gflow.toml`).
+    pub fn set_quota_baseline(&mut self, quota: gflow::config::QuotaConfig) {
+        self.scheduler.set_quota_baseline(quota);
+    }
+
+    /// Snapshot of quota subjects with effective limits and current usage.
+    pub fn quota_status(&self) -> Vec<gflow::core::quota::QuotaStatusEntry> {
+        self.scheduler.quota_status()
+    }
+
+    /// Persisted runtime overrides (for diagnostics / listing).
+    pub fn quota_overrides(&self) -> gflow::config::QuotaConfig {
+        self.scheduler.quota_overrides().clone()
+    }
+
+    /// Merge a runtime quota override; persists via mark_dirty.
+    pub fn merge_quota_override(
+        &mut self,
+        scope: gflow::core::quota::QuotaScope,
+        name: Option<&str>,
+        limits: &gflow::config::QuotaLimits,
+    ) -> bool {
+        let changed = self.scheduler.merge_quota_override(scope, name, limits);
+        if changed {
+            self.mark_dirty();
+        }
+        changed
+    }
+
+    /// Remove a runtime quota override; persists via mark_dirty.
+    pub fn remove_quota_override(
+        &mut self,
+        scope: gflow::core::quota::QuotaScope,
+        name: Option<&str>,
+    ) -> bool {
+        let changed = self.scheduler.remove_quota_override(scope, name);
+        if changed {
+            self.mark_dirty();
+        }
+        changed
+    }
+
     pub fn gpu_available(&self, gpu_index: u32) -> Option<bool> {
         self.scheduler
             .info()

--- a/src/multicall/gflowd/scheduler_runtime/jobs.rs
+++ b/src/multicall/gflowd/scheduler_runtime/jobs.rs
@@ -17,6 +17,26 @@ impl SchedulerRuntime {
         Ok(())
     }
 
+    /// Enforce queue-depth quotas (`max_queued_jobs`) at submission time.
+    /// Running/GPU quotas are enforced by the scheduling loop instead, where
+    /// exceeding them means waiting in the queue rather than rejection.
+    fn check_queue_quota(
+        &self,
+        job: &Job,
+        user_pending_bias: &HashMap<CompactString, usize>,
+        project_pending_bias: &HashMap<CompactString, usize>,
+    ) -> Result<()> {
+        if let Some(reason) = self.scheduler.check_queue_quota(
+            &job.submitted_by,
+            job.project.as_deref(),
+            user_pending_bias,
+            project_pending_bias,
+        ) {
+            bail!("{reason}");
+        }
+        Ok(())
+    }
+
     fn current_reserved_run_names(&self) -> HashSet<String> {
         let mut reserved_names: HashSet<String> = self
             .scheduler
@@ -90,6 +110,7 @@ impl SchedulerRuntime {
     pub async fn submit_job(&mut self, mut job: Job) -> Result<(u32, String, Job)> {
         self.normalize_and_validate_project(&mut job)?;
         Self::validate_shared_job_requirements(&job)?;
+        self.check_queue_quota(&job, &HashMap::new(), &HashMap::new())?;
         let mut reserved_names = self.current_reserved_run_names();
         self.prepare_run_name(&mut job, self.scheduler.next_job_id(), &mut reserved_names);
         let (job_id, run_name) = self.scheduler.submit_job(job);
@@ -115,9 +136,20 @@ impl SchedulerRuntime {
 
         let mut reserved_names = self.current_reserved_run_names();
         let mut normalized_jobs = Vec::with_capacity(batch_size);
+        // Queue-depth quotas must account for jobs accepted earlier in this
+        // same batch, which are not indexed until `scheduler.submit_job` runs.
+        let mut user_pending_bias: HashMap<CompactString, usize> = HashMap::new();
+        let mut project_pending_bias: HashMap<CompactString, usize> = HashMap::new();
         for (next_job_id, mut job) in (self.scheduler.next_job_id()..).zip(jobs) {
             self.normalize_and_validate_project(&mut job)?;
             Self::validate_shared_job_requirements(&job)?;
+            self.check_queue_quota(&job, &user_pending_bias, &project_pending_bias)?;
+            *user_pending_bias
+                .entry(job.submitted_by.clone())
+                .or_default() += 1;
+            if let Some(ref project) = job.project {
+                *project_pending_bias.entry(project.clone()).or_default() += 1;
+            }
             self.prepare_run_name(&mut job, next_job_id, &mut reserved_names);
             normalized_jobs.push(job);
         }

--- a/src/multicall/gflowd/server.rs
+++ b/src/multicall/gflowd/server.rs
@@ -62,6 +62,7 @@ pub async fn run(config: gflow::config::Config) -> anyhow::Result<()> {
         config.daemon.fair_share.clone(),
     )?;
     scheduler_runtime.set_state_saver(state_saver_handle.clone());
+    scheduler_runtime.set_quota_baseline(config.quota.clone());
 
     let scheduler = Arc::new(tokio::sync::RwLock::new(scheduler_runtime));
     let scheduler_clone = Arc::clone(&scheduler);
@@ -179,6 +180,12 @@ pub async fn run(config: gflow::config::Config) -> anyhow::Result<()> {
             get(handlers::get_reservation).delete(handlers::cancel_reservation),
         )
         .route("/stats", get(handlers::get_stats))
+        .route(
+            "/quotas",
+            get(handlers::list_quotas)
+                .put(handlers::set_quota)
+                .delete(handlers::delete_quota),
+        )
         .route("/metrics", get(handlers::get_metrics))
         .route("/debug/state", get(handlers::debug_state))
         .route("/debug/jobs/{id}", get(handlers::debug_job))

--- a/src/multicall/gflowd/server/handlers/mod.rs
+++ b/src/multicall/gflowd/server/handlers/mod.rs
@@ -9,6 +9,7 @@ pub(super) use jobs::{
     set_group_max_concurrency, unignore_gpu_process, update_job,
 };
 pub(super) use metrics::get_metrics;
+pub(super) use quotas::{delete_quota, list_quotas, set_quota};
 pub(super) use reservations::{
     cancel_reservation, create_reservation, get_reservation, list_reservations,
 };
@@ -18,5 +19,6 @@ mod debug;
 mod events;
 mod jobs;
 mod metrics;
+mod quotas;
 mod reservations;
 mod stats;

--- a/src/multicall/gflowd/server/handlers/quotas.rs
+++ b/src/multicall/gflowd/server/handlers/quotas.rs
@@ -1,0 +1,153 @@
+use super::super::state::{reject_if_read_only, ServerState};
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde::Deserialize;
+
+use gflow::config::QuotaLimits;
+use gflow::core::quota::{QuotaScope, QuotaStatusEntry};
+
+/// `GET /quotas` — effective limits and current usage for every quota subject.
+pub(in crate::multicall::gflowd::server) async fn list_quotas(
+    State(server_state): State<ServerState>,
+) -> Response {
+    let state = server_state.scheduler.read().await;
+    let quotas: Vec<QuotaStatusEntry> = state.quota_status();
+    let overrides = state.quota_overrides();
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "quotas": quotas,
+            "overrides": overrides,
+        })),
+    )
+        .into_response()
+}
+
+#[derive(Deserialize)]
+pub(in crate::multicall::gflowd::server) struct SetQuotaRequest {
+    /// `user` | `project` | `default_user` | `default_project`
+    scope: QuotaScope,
+    /// Subject name; required for `user` / `project`, ignored for defaults.
+    #[serde(default)]
+    name: Option<String>,
+    /// Only `Some` fields are written; unset fields keep their current value.
+    #[serde(default)]
+    limits: QuotaLimits,
+}
+
+/// `PUT /quotas` — merge a runtime override (persisted in daemon state).
+pub(in crate::multicall::gflowd::server) async fn set_quota(
+    State(server_state): State<ServerState>,
+    Json(request): Json<SetQuotaRequest>,
+) -> Response {
+    if let Some(resp) = reject_if_read_only(&server_state).await {
+        return resp;
+    }
+
+    if request.scope.is_named() {
+        let valid_name = request
+            .name
+            .as_ref()
+            .is_some_and(|name| !name.trim().is_empty());
+        if !valid_name {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("'name' is required for scope '{:?}'", request.scope)
+                })),
+            )
+                .into_response();
+        }
+    }
+
+    if request.limits.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "at least one limit field must be provided"
+            })),
+        )
+            .into_response();
+    }
+
+    let overrides = {
+        let mut state = server_state.scheduler.write().await;
+        state.merge_quota_override(request.scope, request.name.as_deref(), &request.limits);
+        state.quota_overrides()
+    };
+
+    tracing::info!(
+        scope = ?request.scope,
+        name = ?request.name,
+        "Quota override updated"
+    );
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "scope": request.scope,
+            "name": request.name,
+            "overrides": overrides,
+        })),
+    )
+        .into_response()
+}
+
+#[derive(Deserialize)]
+pub(in crate::multicall::gflowd::server) struct DeleteQuotaQuery {
+    scope: QuotaScope,
+    #[serde(default)]
+    name: Option<String>,
+}
+
+/// `DELETE /quotas?scope=user&name=alice` — remove a runtime override entry.
+pub(in crate::multicall::gflowd::server) async fn delete_quota(
+    State(server_state): State<ServerState>,
+    Query(query): Query<DeleteQuotaQuery>,
+) -> Response {
+    if let Some(resp) = reject_if_read_only(&server_state).await {
+        return resp;
+    }
+
+    if query.scope.is_named() && query.name.as_ref().is_some_and(|n| n.trim().is_empty()) {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("'name' is required for scope '{:?}'", query.scope)
+            })),
+        )
+            .into_response();
+    }
+
+    let (removed, overrides) = {
+        let mut state = server_state.scheduler.write().await;
+        let removed = state.remove_quota_override(query.scope, query.name.as_deref());
+        (removed, state.quota_overrides())
+    };
+
+    if !removed {
+        return (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({
+                "error": "no matching quota override"
+            })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "scope": query.scope,
+            "name": query.name,
+            "removed": true,
+            "overrides": overrides,
+        })),
+    )
+        .into_response()
+}


### PR DESCRIPTION
## Summary

Implements phase 1 of per-user / per-project resource quotas (W-142), following the design approved in the issue discussion.

## What's included

**Config** (`[quota]` section in `gflow.toml`)
- `default_user` / `default_project` fallback limits, plus per-name `[quota.users]` / `[quota.projects]` tables
- Named entries merge over the matching default field-by-field
- Limit fields (all optional, unset = unlimited): `max_running_jobs`, `max_running_gpus`, `max_queued_jobs`

**Enforcement**
- `max_running_jobs` / `max_running_gpus`: gated in the scheduling loop via O(1) per-user / per-project running-usage indexes (maintained on state transitions, rebuilt on state load). Over-limit jobs stay queued with a new `WaitingForQuota` reason (shown as `Quota`).
- `max_queued_jobs`: enforced at submission (single and batch), rejecting over-limit submissions rather than queueing them.
- A job must satisfy **both** its user quota and its project quota; jobs without a project have no project quota.

**Runtime management**
- `gctl quota list` / `gctl quota set` / `gctl quota remove`
- Backed by new `GET/PUT/DELETE /quotas` HTTP endpoints
- Overrides persist in daemon state (like `fair_share_usage`) and take precedence over the `gflow.toml` baseline

**Deferred to phase 2**: cumulative GPU-time quotas (`max_gpu_hours`), which will reuse the fair-share decayed usage ledger.

## Verification

- `cargo fmt --check`, `cargo clippy --all-targets --all-features --workspace -- -D warnings`: clean
- `cargo test --lib`: 347 passed, 1 failed — the failure (`batch_submit_assigns_unique_default_run_names`) is pre-existing and environmental: it fails on a clean checkout too because this machine has a live tmux session literally named `gjob-1`, which the run-name allocator treats as reserved. Unrelated to this change.
- Integration/e2e suites: all pass (`integration_test` 17, `daemon_e2e_test` 8, `cancel_during_execution_test` 3)
- New tests: config parsing/merge, scheduling gates (per-user jobs/GPUs, per-project), usage-index rebuild, override serde roundtrip, queue-depth checks with batch bias, and client wiremock tests
- Manual end-to-end smoke test against a running daemon confirmed `gctl quota list/set/remove` and `GET /quotas` behave correctly, including field-wise merge of named entries over defaults.

## Docs

`configuration.md`, `multi-user.md`, `gctl-reference.md` (+ zh-CN), and `CHANGELOG.md` updated.
