### PR TITLE
feat: recover jobs across daemon restart

### DIFF
--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -1,6 +1,28 @@
 use crate::core::job::Job;
 use anyhow::Result;
 
+/// The result reported by an execution runner after the payload exits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExecutionResult {
+    pub job_id: u32,
+    pub exit_code: Option<i32>,
+    pub signal: Option<i32>,
+}
+
+impl ExecutionResult {
+    pub fn succeeded(self) -> bool {
+        self.exit_code == Some(0) && self.signal.is_none()
+    }
+}
+
+/// The state of the external execution entity for a job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExecutionStatus {
+    Running,
+    Finished(ExecutionResult),
+    Missing,
+}
+
 /// Abstraction over how a job's payload is actually executed.
 ///
 /// The default implementation (`ProcessExecutor`) spawns a detached child
@@ -29,12 +51,31 @@ pub trait Executor: Send + Sync {
         Ok(())
     }
 
+    /// Return the durable state of the job's external execution entity.
+    ///
+    /// The default implementation preserves the legacy executor contract: an
+    /// executor that cannot distinguish an exited process from an unavailable
+    /// probe is treated as alive and is therefore never falsely failed.
+    fn execution_status(&self, job_id: u32, run_name: Option<&str>) -> ExecutionStatus {
+        if self.is_running(job_id, run_name) {
+            ExecutionStatus::Running
+        } else {
+            ExecutionStatus::Missing
+        }
+    }
+
     /// Whether the job's underlying execution is still alive (zombie monitor).
     ///
     /// Executors that cannot probe liveness should return `true` so they never
     /// false-positive a running job as a zombie.
     fn is_running(&self, _job_id: u32, _run_name: Option<&str>) -> bool {
         true
+    }
+
+    /// Return execution results that were recorded while the daemon was
+    /// running or offline. The default executor has no durable result store.
+    fn collect_finished(&self) -> Vec<ExecutionResult> {
+        Vec::new()
     }
 
     /// Best-effort cleanup after a job reaches a terminal state.

--- a/src/multicall/gflowd/commands/reload.rs
+++ b/src/multicall/gflowd/commands/reload.rs
@@ -26,6 +26,30 @@ pub async fn handle_reload(
         .collect();
     old_pids.insert(pid);
 
+    // Persist the latest scheduler snapshot before the replacement daemon
+    // loads state. SIGUSR2 is a reload handoff, so the old daemon leaves
+    // durable job runners alive while it flushes and exits.
+    println!("Preparing old daemon for reload...");
+    tracing::info!("Signaling old daemon (PID {}) to save state and exit", pid);
+    unsafe {
+        libc::kill(pid as libc::pid_t, libc::SIGUSR2);
+    }
+
+    let mut exited = false;
+    for i in 0..30 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        if !is_process_running(pid) {
+            tracing::info!("Old daemon has saved state and exited");
+            exited = true;
+            break;
+        }
+        if i == 29 {
+            tracing::warn!(
+                "Old daemon did not exit within 3 seconds; continuing with the replacement"
+            );
+        }
+    }
+
     // 2. Start new daemon instance in temporary tmux session
     println!("Starting new daemon instance...");
     tracing::info!("Starting new daemon instance...");
@@ -108,31 +132,11 @@ pub async fn handle_reload(
         );
     }
 
-    // 6. Signal old process to shutdown (SIGUSR2)
+    // 6. The old daemon was handed off before the replacement started. The
+    // replacement has now been health-checked and can take the standard name.
     println!("Switching to new daemon...");
-    tracing::info!("Signaling old daemon (PID {}) to shutdown", pid);
-    unsafe {
-        libc::kill(pid as libc::pid_t, libc::SIGUSR2);
-    }
 
-    // 7. Wait for old process to exit
-    let mut exited = false;
-    for i in 0..30 {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        if !is_process_running(pid) {
-            tracing::info!("Old daemon has exited");
-            exited = true;
-            break;
-        }
-        if i == 29 {
-            tracing::warn!(
-                "Old daemon did not exit within 3 seconds. \
-                 New daemon is running, but old process may need manual cleanup."
-            );
-        }
-    }
-
-    // 8. Rename new tmux session to standard name
+    // 7. Rename new tmux session to standard name
     // Try to rename first. If it fails because the target name exists, kill the old session and retry.
     let rename_result = Tmux::with_command(
         RenameSession::new()

--- a/src/multicall/gflowd/events.rs
+++ b/src/multicall/gflowd/events.rs
@@ -53,7 +53,14 @@ pub enum SchedulerEvent {
         run_name: Option<String>,
     },
 
-    /// A zombie job was detected (tmux session disappeared)
+    /// A job's durable runner recorded a payload exit result.
+    JobExecutionFinished {
+        job_id: u32,
+        exit_code: Option<i32>,
+        signal: Option<i32>,
+    },
+
+    /// A zombie job was detected (runner/session disappeared without a result)
     ZombieJobDetected { job_id: u32 },
 
     /// Periodic health check trigger
@@ -80,6 +87,7 @@ impl SchedulerEvent {
             Self::ManualGpuOverrideChanged { .. } => "manual_gpu_override_changed",
             Self::MemoryAvailabilityChanged { .. } => "memory_availability_changed",
             Self::JobTimedOut { .. } => "job_timed_out",
+            Self::JobExecutionFinished { .. } => "job_execution_finished",
             Self::ZombieJobDetected { .. } => "zombie_job_detected",
             Self::PeriodicHealthCheck => "periodic_health_check",
             Self::ReservationCreated { .. } => "reservation_created",

--- a/src/multicall/gflowd/executor.rs
+++ b/src/multicall/gflowd/executor.rs
@@ -1,9 +1,11 @@
 use anyhow::{Context, Result};
-use gflow::core::executor::Executor;
+use gflow::core::executor::{ExecutionResult, ExecutionStatus, Executor};
 use gflow::core::job::{Job, JobState};
 use gflow::utils::substitute_parameters;
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
+use std::io::Write;
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -11,23 +13,42 @@ use std::time::{Duration, Instant};
 /// How long to wait for a SIGTERM'd process group to exit before escalating
 /// to SIGKILL.
 const TERMINATE_GRACE: Duration = Duration::from_secs(5);
+const RUNNER_METADATA_VERSION: u32 = 1;
 
-/// A spawned child process tracked by job id.
+/// A spawned runner tracked locally for child reaping. The durable metadata is
+/// the source of truth used by a fresh daemon instance.
 struct TrackedProcess {
-    /// Child pid, which equals the process group id because the child calls
+    /// Runner pid, which equals the process group id because the runner calls
     /// `setsid()` before exec.
     pid: i32,
 }
 
-/// Process-backed executor: spawns `bash -c <wrapped>` in its own session
-/// (`setsid`) with stdout/stderr redirected to `logs/<job_id>.log`.
-///
-/// Completion is reported by the wrapped command itself via
-/// `gcancel --finish` / `gcancel --fail` (same channel as the tmux executor),
-/// so the daemon's state machine is untouched. This executor additionally
-/// tracks the child so the canceller can kill the whole process group and the
-/// zombie monitor can probe real process liveness.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RunnerMetadata {
+    version: u32,
+    job_id: u32,
+    pid: i32,
+    pgid: i32,
+    /// Linux `/proc/<pid>/stat` start time. `None` on platforms without procfs.
+    #[serde(default)]
+    start_time: Option<u64>,
+    result_path: std::path::PathBuf,
+}
+
+#[derive(Debug, Deserialize)]
+struct RunnerResultFile {
+    job_id: u32,
+    exit_code: i32,
+    #[serde(default)]
+    signal: Option<i32>,
+}
+
+/// Process-backed executor. Each job is owned by an independent shell runner
+/// in its own session. The runner writes an atomic result file after the
+/// payload exits, so a new daemon can adopt the process or collect its result.
 pub struct ProcessExecutor {
+    /// Kept for child reaping while this daemon is alive. Re-adoption never
+    /// relies on this registry; it reads the durable runner metadata instead.
     processes: Arc<Mutex<HashMap<u32, TrackedProcess>>>,
 }
 
@@ -45,16 +66,137 @@ impl ProcessExecutor {
     }
 
     fn is_alive(pid: i32) -> bool {
-        unsafe { libc::kill(pid, 0) == 0 }
+        let rc = unsafe { libc::kill(pid, 0) };
+        rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
     }
 
-    /// Build the command line executed by the child shell.
-    ///
-    /// The user command is embedded raw (no key-escaping): it is passed as a
-    /// single argv element to `bash -c`, so the shell parses it exactly as the
-    /// user wrote it. `&&`/`||` chain the completion reporters onto the exit
-    /// code of the user command.
-    fn build_wrapped_command(job: &Job) -> Result<String> {
+    fn group_is_alive(pgid: i32) -> bool {
+        let rc = unsafe { libc::kill(-pgid, 0) };
+        rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+    }
+
+    fn process_start_time(pid: i32) -> Option<u64> {
+        let stat = fs::read_to_string(format!("/proc/{pid}/stat")).ok()?;
+        let end = stat.rfind(')')?;
+        let mut fields = stat.get(end + 1..)?.split_whitespace();
+        let _state = fields.next()?;
+        let _ppid = fields.next()?;
+        let fields: Vec<_> = fields.collect();
+        fields.get(17)?.parse().ok()
+    }
+
+    fn process_identity_matches(metadata: &RunnerMetadata) -> bool {
+        if !Self::is_alive(metadata.pid) {
+            return false;
+        }
+
+        let current_pgid = unsafe { libc::getpgid(metadata.pid) };
+        if current_pgid != metadata.pgid {
+            return false;
+        }
+
+        metadata
+            .start_time
+            .map(|expected| Self::process_start_time(metadata.pid) == Some(expected))
+            .unwrap_or(true)
+    }
+
+    fn write_json_atomic<T: Serialize>(path: &std::path::Path, value: &T) -> Result<()> {
+        let parent = path
+            .parent()
+            .ok_or_else(|| anyhow::anyhow!("JSON path has no parent: {}", path.display()))?;
+        fs::create_dir_all(parent)?;
+        let tmp_path = parent.join(format!(
+            ".{}.tmp.{}",
+            path.file_name()
+                .and_then(|name| name.to_str())
+                .unwrap_or("runner"),
+            std::process::id()
+        ));
+        let bytes = serde_json::to_vec(value)?;
+        let mut file = fs::File::create(&tmp_path)?;
+        file.write_all(&bytes)?;
+        file.write_all(b"\n")?;
+        file.sync_all()?;
+        fs::rename(&tmp_path, path)?;
+        Ok(())
+    }
+
+    fn metadata(job_id: u32) -> Result<RunnerMetadata> {
+        let path = gflow::paths::get_runner_metadata_path(job_id)?;
+        let bytes = fs::read(path)?;
+        Ok(serde_json::from_slice(&bytes)?)
+    }
+
+    fn result(job_id: u32) -> Option<ExecutionResult> {
+        let path = gflow::paths::get_runner_result_path(job_id).ok()?;
+        let bytes = fs::read(path).ok()?;
+        let result = match serde_json::from_slice::<RunnerResultFile>(&bytes) {
+            Ok(result) => result,
+            Err(error) => {
+                tracing::warn!(job_id, %error, "Ignoring incomplete runner result file");
+                return None;
+            }
+        };
+        if result.job_id != job_id {
+            tracing::warn!(
+                expected_job_id = job_id,
+                result_job_id = result.job_id,
+                "Ignoring runner result for a different job"
+            );
+            return None;
+        }
+        Some(ExecutionResult {
+            job_id,
+            exit_code: Some(result.exit_code),
+            signal: result.signal,
+        })
+    }
+
+    fn remove_runner_files(job_id: u32) {
+        for path in [
+            gflow::paths::get_runner_metadata_path(job_id).ok(),
+            gflow::paths::get_runner_result_path(job_id).ok(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            let _ = fs::remove_file(path);
+        }
+    }
+
+    fn status_from_metadata(&self, job_id: u32) -> ExecutionStatus {
+        if let Some(result) = Self::result(job_id) {
+            return ExecutionStatus::Finished(result);
+        }
+
+        let Ok(metadata) = Self::metadata(job_id) else {
+            return self
+                .processes
+                .lock()
+                .unwrap()
+                .get(&job_id)
+                .filter(|process| Self::is_alive(process.pid))
+                .map(|_| ExecutionStatus::Running)
+                .unwrap_or(ExecutionStatus::Missing);
+        };
+
+        if metadata.version != RUNNER_METADATA_VERSION || metadata.job_id != job_id {
+            tracing::warn!(
+                job_id,
+                "Ignoring runner metadata with an incompatible identity"
+            );
+            return ExecutionStatus::Missing;
+        }
+
+        if Self::process_identity_matches(&metadata) {
+            ExecutionStatus::Running
+        } else {
+            ExecutionStatus::Missing
+        }
+    }
+
+    fn build_user_command(job: &Job) -> Result<String> {
         let mut user_command = String::new();
 
         if let Some(script) = &job.script {
@@ -62,7 +204,6 @@ impl ProcessExecutor {
                 user_command.push_str(&format!("bash {script_str}"));
             }
         } else if let Some(cmd) = &job.command {
-            // Apply parameter substitution
             let substituted = substitute_parameters(cmd, &job.parameters)?;
             user_command.push_str(&substituted);
         } else {
@@ -73,8 +214,24 @@ impl ProcessExecutor {
             user_command = format!("conda activate {conda_env} && {user_command}");
         }
 
+        Ok(user_command)
+    }
+
+    /// Build the detached runner shell. The payload is executed by a nested
+    /// bash so `exit` in user input cannot skip the result write performed by
+    /// the outer runner.
+    fn build_runner_command(job: &Job, result_path: &std::path::Path) -> Result<String> {
+        let user_command = Self::build_user_command(job)?;
+        let payload = shell_escape::escape(user_command.into());
+        let result = shell_escape::escape(result_path.to_string_lossy());
+
         Ok(format!(
-            "{user_command} && gcancel --finish {job_id} || gcancel --fail {job_id}",
+            "bash -c {payload}\n\
+             status=$?\n\
+             finished_at=$(date +%s 2>/dev/null || printf 0)\n\
+             tmp={result}.tmp.$$\n\
+             printf '{{\"version\":1,\"job_id\":{job_id},\"exit_code\":%s,\"signal\":null,\"finished_at_unix_secs\":%s}}\\n' \"$status\" \"$finished_at\" > \"$tmp\" && mv -f \"$tmp\" {result}\n\
+             exit \"$status\"",
             job_id = job.id,
         ))
     }
@@ -96,7 +253,9 @@ impl Executor for ProcessExecutor {
     }
 
     fn execute(&self, job: &Job) -> Result<()> {
-        let wrapped_command = Self::build_wrapped_command(job)?;
+        let result_path = gflow::paths::get_runner_result_path(job.id)?;
+        let runner_command = Self::build_runner_command(job, &result_path)?;
+        Self::remove_runner_files(job.id);
 
         let log_path = gflow::paths::prepare_log_file_path(job.id)?;
         if let Some(parent) = log_path.parent() {
@@ -111,7 +270,7 @@ impl Executor for ProcessExecutor {
         let mut command = Command::new("bash");
         command
             .arg("-c")
-            .arg(&wrapped_command)
+            .arg(&runner_command)
             .current_dir(&job.run_dir)
             .stdin(Stdio::null())
             .stdout(Stdio::from(log_file))
@@ -129,8 +288,8 @@ impl Executor for ProcessExecutor {
             );
         }
 
-        // Detach the child into its own session/process group so the whole
-        // group can be signalled with kill(-pgid, ...).
+        // Detach the runner into its own session/process group so it survives
+        // daemon exit and the whole group can be signalled with kill(-pgid, ...).
         #[cfg(unix)]
         {
             use std::os::unix::process::CommandExt;
@@ -141,22 +300,38 @@ impl Executor for ProcessExecutor {
 
         let mut child = command.spawn().with_context(|| {
             format!(
-                "Failed to spawn job {}: bash -c {:?}",
-                job.id, wrapped_command
+                "Failed to spawn runner for job {}: bash -c {:?}",
+                job.id, runner_command
             )
         })?;
         let pid = child.id() as i32;
-        let pgid = pid; // setsid() makes the child a session leader
+        let pgid = pid;
+        let metadata = RunnerMetadata {
+            version: RUNNER_METADATA_VERSION,
+            job_id: job.id,
+            pid,
+            pgid,
+            start_time: Self::process_start_time(pid),
+            result_path,
+        };
+
+        if let Err(error) =
+            Self::write_json_atomic(&gflow::paths::get_runner_metadata_path(job.id)?, &metadata)
+        {
+            unsafe {
+                libc::kill(-pgid, libc::SIGKILL);
+            }
+            let _ = child.wait();
+            return Err(error).context("Failed to persist runner metadata");
+        }
 
         self.processes
             .lock()
             .unwrap()
             .insert(job.id, TrackedProcess { pid: pgid });
 
-        // Reap the child in the background and drop the registry entry once it
-        // exits. The wrapper's `gcancel --finish/--fail` reports the final job
-        // state; the zombie monitor uses the registry to detect jobs whose
-        // process died without reporting.
+        // Reap the runner while this daemon is alive. The result file remains
+        // durable until the scheduler transitions the job and calls cleanup.
         let processes = Arc::clone(&self.processes);
         let job_id = job.id;
         std::thread::spawn(move || {
@@ -165,25 +340,66 @@ impl Executor for ProcessExecutor {
             registry.remove(&job_id);
         });
 
-        tracing::info!(job_id = job.id, pid, "Spawned job process group");
+        tracing::info!(job_id = job.id, pid, "Spawned durable job runner");
         Ok(())
     }
 
-    fn terminate(&self, job_id: u32, _run_name: Option<&str>) -> Result<()> {
-        let pid = match self.processes.lock().unwrap().get(&job_id) {
-            Some(process) => process.pid,
-            None => return Ok(()), // nothing tracked (already finished/reaped)
+    fn execution_status(&self, job_id: u32, _run_name: Option<&str>) -> ExecutionStatus {
+        self.status_from_metadata(job_id)
+    }
+
+    fn collect_finished(&self) -> Vec<ExecutionResult> {
+        let Ok(dir) = gflow::paths::get_runner_dir() else {
+            return Vec::new();
         };
+        let Ok(entries) = fs::read_dir(dir) else {
+            return Vec::new();
+        };
+
+        entries
+            .filter_map(|entry| entry.ok())
+            .filter_map(|entry| {
+                let path = entry.path();
+                if path.extension().and_then(|ext| ext.to_str()) != Some("json")
+                    || path.file_name()?.to_str()?.contains(".result.")
+                {
+                    return None;
+                }
+                let metadata =
+                    serde_json::from_slice::<RunnerMetadata>(&fs::read(path).ok()?).ok()?;
+                let result = Self::result(metadata.job_id)?;
+                Some(result)
+            })
+            .collect()
+    }
+
+    fn terminate(&self, job_id: u32, _run_name: Option<&str>) -> Result<()> {
+        let metadata = Self::metadata(job_id).ok();
+        let (pid, pgid) = metadata
+            .as_ref()
+            .map(|metadata| (metadata.pid, metadata.pgid))
+            .or_else(|| {
+                self.processes
+                    .lock()
+                    .unwrap()
+                    .get(&job_id)
+                    .map(|process| (process.pid, process.pid))
+            })
+            .unwrap_or((0, 0));
+        if pid == 0 || pgid == 0 {
+            return Ok(());
+        }
+        if let Some(metadata) = metadata.as_ref() {
+            if !Self::process_identity_matches(metadata) {
+                return Ok(());
+            }
+        }
 
         // SIGTERM to the whole process group, then escalate to SIGKILL after a
         // grace period in the background (never blocks the scheduler).
-        let rc = unsafe { libc::kill(-pid, libc::SIGTERM) };
+        let rc = unsafe { libc::kill(-pgid, libc::SIGTERM) };
         if rc != 0 {
             let err = std::io::Error::last_os_error();
-            // ESRCH: the group is already gone. EPERM: on some platforms
-            // (macOS) signalling a dead or foreign process group returns EPERM
-            // instead of ESRCH; either way there is nothing we own left to
-            // terminate (and we must not touch a reused pid's group).
             if matches!(err.raw_os_error(), Some(libc::ESRCH) | Some(libc::EPERM)) {
                 return Ok(());
             }
@@ -193,63 +409,80 @@ impl Executor for ProcessExecutor {
         std::thread::spawn(move || {
             let deadline = Instant::now() + TERMINATE_GRACE;
             while Instant::now() < deadline {
-                if !Self::is_alive(pid) {
+                if !Self::group_is_alive(pgid) {
                     return;
                 }
                 std::thread::sleep(Duration::from_millis(100));
             }
-            tracing::warn!(pid, "Process group ignored SIGTERM, sending SIGKILL");
+            tracing::warn!(pid, pgid, "Process group ignored SIGTERM, sending SIGKILL");
             unsafe {
-                libc::kill(-pid, libc::SIGKILL);
+                libc::kill(-pgid, libc::SIGKILL);
             }
         });
         Ok(())
     }
 
-    fn is_running(&self, job_id: u32, _run_name: Option<&str>) -> bool {
-        let Some(pid) = self
-            .processes
-            .lock()
-            .unwrap()
-            .get(&job_id)
-            .map(|process| process.pid)
-        else {
-            return false;
-        };
-        Self::is_alive(pid)
+    fn is_running(&self, job_id: u32, run_name: Option<&str>) -> bool {
+        matches!(
+            self.execution_status(job_id, run_name),
+            ExecutionStatus::Running
+        )
+    }
+
+    fn cleanup(&self, job: &Job) {
+        Self::remove_runner_files(job.id);
+        if let Ok(mut processes) = self.processes.lock() {
+            processes.remove(&job.id);
+        }
     }
 
     fn shutdown(&self) {
-        let pids: Vec<i32> = self
-            .processes
-            .lock()
-            .unwrap()
-            .values()
-            .map(|process| process.pid)
-            .collect();
-        if pids.is_empty() {
+        let mut groups: HashMap<i32, i32> = HashMap::new();
+        if let Ok(dir) = gflow::paths::get_runner_dir() {
+            if let Ok(entries) = fs::read_dir(dir) {
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    if path.extension().and_then(|ext| ext.to_str()) != Some("json") {
+                        continue;
+                    }
+                    if let Ok(metadata) = serde_json::from_slice::<RunnerMetadata>(
+                        &fs::read(path).unwrap_or_default(),
+                    ) {
+                        if Self::process_identity_matches(&metadata) {
+                            groups.insert(metadata.pgid, metadata.pid);
+                        }
+                    }
+                }
+            }
+        }
+        if let Ok(processes) = self.processes.lock() {
+            for process in processes.values() {
+                groups.entry(process.pid).or_insert(process.pid);
+            }
+        }
+        if groups.is_empty() {
             return;
         }
 
-        tracing::info!(processes = pids.len(), "Terminating managed job processes");
-        for pid in &pids {
+        tracing::info!(processes = groups.len(), "Terminating managed job runners");
+        for pgid in groups.keys() {
             unsafe {
-                libc::kill(-*pid, libc::SIGTERM);
+                libc::kill(-*pgid, libc::SIGTERM);
             }
         }
 
         let deadline = Instant::now() + TERMINATE_GRACE;
         while Instant::now() < deadline {
-            if pids.iter().all(|pid| !Self::is_alive(*pid)) {
+            if groups.keys().all(|pgid| !Self::group_is_alive(*pgid)) {
                 return;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
 
-        for pid in pids {
-            tracing::warn!(pid, "Process group survived SIGTERM, sending SIGKILL");
+        for (pgid, pid) in groups {
+            tracing::warn!(pid, pgid, "Process group survived SIGTERM, sending SIGKILL");
             unsafe {
-                libc::kill(-pid, libc::SIGKILL);
+                libc::kill(-pgid, libc::SIGKILL);
             }
         }
     }
@@ -385,78 +618,39 @@ mod tests {
     }
 
     #[test]
-    fn test_process_wrapped_command_basic() {
+    fn test_runner_command_records_exit_code_without_http_reporting() {
         let job = job_with_command(123, "echo hello");
-        let wrapped = ProcessExecutor::build_wrapped_command(&job).unwrap();
-        assert_eq!(
-            wrapped,
-            r#"echo hello && gcancel --finish 123 || gcancel --fail 123"#
-        );
+        let result_path = PathBuf::from("/tmp/runner.result.json");
+        let command = ProcessExecutor::build_runner_command(&job, &result_path).unwrap();
+        assert!(command.contains("bash -c"));
+        assert!(command.contains("exit_code"));
+        assert!(command.contains("runner.result.json"));
+        assert!(!command.contains("gcancel"));
     }
 
     #[test]
-    fn test_process_wrapped_command_keeps_quotes_unescaped() {
-        // No key-escaping: quotes reach `bash -c` verbatim.
-        let job = job_with_command(456, r#"echo "hello world""#);
-        let wrapped = ProcessExecutor::build_wrapped_command(&job).unwrap();
-        assert_eq!(
-            wrapped,
-            r#"echo "hello world" && gcancel --finish 456 || gcancel --fail 456"#
-        );
+    fn test_runner_command_isolates_payload_exit() {
+        let job = job_with_command(456, "exit 7");
+        let command =
+            ProcessExecutor::build_runner_command(&job, PathBuf::from("/tmp/result").as_path())
+                .unwrap();
+        assert!(command.contains("bash -c 'exit 7'"));
+        assert!(command.contains("exit \"$status\""));
     }
 
     #[test]
-    fn test_process_wrapped_command_keeps_dollar_and_backtick_unescaped() {
-        let job = job_with_command(200, "echo $HOME `date`");
-        let wrapped = ProcessExecutor::build_wrapped_command(&job).unwrap();
-        assert_eq!(
-            wrapped,
-            r#"echo $HOME `date` && gcancel --finish 200 || gcancel --fail 200"#
-        );
-    }
-
-    #[test]
-    fn test_process_wrapped_command_with_script() {
-        let job = Job {
-            id: 789,
-            script: Some(Box::new(PathBuf::from("/tmp/script.sh"))),
-            state: JobState::Queued,
-            run_dir: PathBuf::from("/tmp"),
-            ..Default::default()
-        };
-        let wrapped = ProcessExecutor::build_wrapped_command(&job).unwrap();
-        assert_eq!(
-            wrapped,
-            r#"bash /tmp/script.sh && gcancel --finish 789 || gcancel --fail 789"#
-        );
-    }
-
-    #[test]
-    fn test_process_wrapped_command_with_conda_env() {
-        let job = Job {
-            id: 321,
-            command: Some("python train.py".into()),
-            conda_env: Some("ml".into()),
-            state: JobState::Queued,
-            run_dir: PathBuf::from("/tmp"),
-            ..Default::default()
-        };
-        let wrapped = ProcessExecutor::build_wrapped_command(&job).unwrap();
-        assert_eq!(
-            wrapped,
-            r#"conda activate ml && python train.py && gcancel --finish 321 || gcancel --fail 321"#
-        );
-    }
-
-    #[test]
-    fn test_process_wrapped_command_rejects_empty_job() {
+    fn test_runner_command_rejects_empty_job() {
         let job = Job {
             id: 1,
             state: JobState::Queued,
             run_dir: PathBuf::from("/tmp"),
             ..Default::default()
         };
-        assert!(ProcessExecutor::build_wrapped_command(&job).is_err());
+        assert!(ProcessExecutor::build_runner_command(
+            &job,
+            PathBuf::from("/tmp/result").as_path()
+        )
+        .is_err());
     }
 
     #[test]
@@ -517,6 +711,50 @@ mod tests {
                 "registry entry should be removed after the child exits"
             );
             assert!(!executor.is_running(9001, None));
+        })
+    }
+
+    #[test]
+    fn test_process_executor_re_adopts_runner_and_collects_exit_code() {
+        with_isolated_data_dir(|| {
+            let executor = ProcessExecutor::new();
+            let job = job_with_command(9004, "sleep 1; exit 7");
+            executor.execute(&job).unwrap();
+
+            let metadata_path = gflow::paths::get_runner_metadata_path(job.id).unwrap();
+            assert!(metadata_path.exists(), "runner metadata should be durable");
+            assert!(executor.is_running(job.id, None));
+
+            // A fresh executor has no in-memory registry, but it must still be
+            // able to adopt the live runner from metadata.
+            drop(executor);
+            let adopted = ProcessExecutor::new();
+            assert!(adopted.is_running(job.id, None));
+
+            let deadline = std::time::Instant::now() + Duration::from_secs(10);
+            let result = loop {
+                if let Some(result) = adopted
+                    .collect_finished()
+                    .into_iter()
+                    .find(|result| result.job_id == job.id)
+                {
+                    break result;
+                }
+                assert!(
+                    std::time::Instant::now() < deadline,
+                    "runner did not persist an exit result"
+                );
+                std::thread::sleep(Duration::from_millis(50));
+            };
+            assert_eq!(result.exit_code, Some(7));
+            assert!(!result.succeeded());
+            assert!(matches!(
+                adopted.execution_status(job.id, None),
+                ExecutionStatus::Finished(_)
+            ));
+
+            adopted.cleanup(&job);
+            assert!(!metadata_path.exists());
         })
     }
 

--- a/src/multicall/gflowd/scheduler_runtime.rs
+++ b/src/multicall/gflowd/scheduler_runtime.rs
@@ -13,7 +13,7 @@ pub use event_loop::run_event_driven;
 use super::state_saver::StateSaverHandle;
 use anyhow::{bail, Context, Result};
 use compact_str::CompactString;
-use gflow::core::executor::Executor;
+use gflow::core::executor::{ExecutionResult, ExecutionStatus, Executor};
 use gflow::core::gpu::{GPUSlot, GpuUuid};
 use gflow::core::info::IgnoredGpuProcess;
 use gflow::core::job::{GpuSharingMode, Job, JobSpec, JobState};
@@ -28,6 +28,16 @@ use std::{
 use tokio::sync::RwLock;
 
 pub type SharedState = Arc<RwLock<SchedulerRuntime>>;
+
+/// State transitions produced while the daemon re-adopts jobs during startup.
+#[derive(Debug, Clone)]
+pub(crate) struct RecoveryOutcome {
+    pub job_id: u32,
+    pub final_state: JobState,
+    pub gpu_ids: Option<gflow::core::job::GpuIds>,
+    pub memory_mb: Option<u64>,
+    pub retry_job_id: Option<u32>,
+}
 
 /// Wrapper to make Arc<dyn Executor> compatible with Box<dyn Executor>
 struct ArcExecutorWrapper(Arc<dyn Executor>);

--- a/src/multicall/gflowd/scheduler_runtime/event_loop.rs
+++ b/src/multicall/gflowd/scheduler_runtime/event_loop.rs
@@ -9,6 +9,14 @@ pub async fn run_event_driven(
     event_bus: Arc<EventBus>,
     gpu_poll_interval: Duration,
 ) {
+    // Re-adopt execution entities before the first scheduling cycle. This is
+    // intentionally done after state loading but before new queued work is
+    // started, so resources from recovered Running jobs remain accounted for.
+    let recovery_outcomes = {
+        let mut state_guard = shared_state.write().await;
+        state_guard.recover_running_jobs().await
+    };
+
     // Spawn all event handlers and monitors
     let handles = vec![
         // Scheduler trigger handler with debouncing
@@ -76,6 +84,23 @@ pub async fn run_event_driven(
                 .instrument(tracing::info_span!("metrics_updater_task")),
         ),
     ];
+
+    for outcome in recovery_outcomes {
+        event_bus.publish(SchedulerEvent::JobCompleted {
+            job_id: outcome.job_id,
+            final_state: outcome.final_state,
+            gpu_ids: outcome.gpu_ids,
+            memory_mb: outcome.memory_mb,
+        });
+        if let Some(job_id) = outcome.retry_job_id {
+            event_bus.publish(SchedulerEvent::JobSubmitted { job_id });
+        }
+    }
+
+    // Do not rely on the broadcast delivery race at startup to schedule retry
+    // jobs. Run one scheduling pass directly after recovery; subsequent state
+    // changes continue to use the event-driven trigger.
+    trigger_scheduling(&shared_state, &event_bus).await;
 
     // Wait for all handlers (they run forever)
     for handle in handles {
@@ -162,6 +187,15 @@ async fn trigger_scheduling(state: &SharedState, event_bus: &Arc<EventBus>) {
         #[cfg(feature = "metrics")]
         gflow::metrics::observe_scheduler_latency("trigger_scheduling", started_at.elapsed());
         return;
+    }
+
+    // Persist the Running transition before spawning any external runner. The
+    // periodic saver still batches ordinary mutations, but a crash in the
+    // handoff window must not leave a durable runner with no corresponding job
+    // state for the next daemon to adopt.
+    {
+        let mut state_guard = state.write().await;
+        state_guard.save_state_if_dirty().await;
     }
 
     tracing::info!(

--- a/src/multicall/gflowd/scheduler_runtime/jobs.rs
+++ b/src/multicall/gflowd/scheduler_runtime/jobs.rs
@@ -1,6 +1,94 @@
 use super::*;
 
 impl SchedulerRuntime {
+    /// Re-adopt persisted Running jobs before scheduling starts. A live runner
+    /// remains Running; a durable result is finalized immediately; a missing
+    /// runner/result is treated as an execution failure so resources cannot be
+    /// stranded forever after daemon downtime.
+    pub(crate) async fn recover_running_jobs(&mut self) -> Vec<RecoveryOutcome> {
+        let running_jobs: Vec<Job> = self
+            .jobs()
+            .into_iter()
+            .filter(|job| job.state == JobState::Running)
+            .collect();
+        let mut outcomes = Vec::new();
+
+        for job in running_jobs {
+            let status = self
+                .executor
+                .execution_status(job.id, job.run_name.as_deref());
+            match status {
+                ExecutionStatus::Running => {
+                    tracing::info!(job_id = job.id, "Re-adopted running job runner");
+                }
+                ExecutionStatus::Finished(result) => {
+                    tracing::info!(
+                        job_id = job.id,
+                        exit_code = ?result.exit_code,
+                        signal = ?result.signal,
+                        "Recovered completed job runner result"
+                    );
+                    if let Some(outcome) = self.finalize_recovered_job(job, result).await {
+                        outcomes.push(outcome);
+                    }
+                }
+                ExecutionStatus::Missing => {
+                    tracing::warn!(
+                        job_id = job.id,
+                        "Running job has no live runner or durable result; marking it failed"
+                    );
+                    let job_id = job.id;
+                    if let Some(outcome) = self
+                        .finalize_recovered_job(
+                            job,
+                            ExecutionResult {
+                                job_id,
+                                exit_code: None,
+                                signal: None,
+                            },
+                        )
+                        .await
+                    {
+                        outcomes.push(outcome);
+                    }
+                }
+            }
+        }
+
+        outcomes
+    }
+
+    async fn finalize_recovered_job(
+        &mut self,
+        job: Job,
+        result: ExecutionResult,
+    ) -> Option<RecoveryOutcome> {
+        let gpu_ids = job.gpu_ids.clone();
+        let memory_mb = job.memory_limit_mb;
+
+        if result.succeeded() {
+            if self.finish_job(job.id).await {
+                return Some(RecoveryOutcome {
+                    job_id: job.id,
+                    final_state: JobState::Finished,
+                    gpu_ids,
+                    memory_mb,
+                    retry_job_id: None,
+                });
+            }
+            return None;
+        }
+
+        let retry_job_id = self.fail_job(job.id).await?;
+        Some(RecoveryOutcome {
+            job_id: job.id,
+            final_state: JobState::Failed,
+            gpu_ids,
+            memory_mb,
+            retry_job_id,
+        })
+    }
+
     fn normalize_and_validate_project(&self, job: &mut Job) -> Result<()> {
         let normalized =
             gflow::utils::validate_project_policy(job.project.as_deref(), &self.projects_config)?;

--- a/src/multicall/gflowd/scheduler_runtime/monitors.rs
+++ b/src/multicall/gflowd/scheduler_runtime/monitors.rs
@@ -85,13 +85,44 @@ pub(super) async fn zombie_monitor_task(state: SharedState, event_bus: Arc<Event
             continue;
         }
 
+        let running_job_ids: HashSet<u32> = running_jobs.iter().map(|(id, _, _)| *id).collect();
+        let finished_results: Vec<_> = executor
+            .collect_finished()
+            .into_iter()
+            .filter(|result| running_job_ids.contains(&result.job_id))
+            .collect();
+        let finished_ids: HashSet<u32> = finished_results
+            .iter()
+            .map(|result| result.job_id)
+            .collect();
+
+        // Process completion results before applying the startup grace period:
+        // a payload that exited successfully while the daemon was offline must
+        // be finalized immediately after its result file becomes visible.
+        for result in finished_results {
+            tracing::info!(
+                job_id = result.job_id,
+                exit_code = ?result.exit_code,
+                signal = ?result.signal,
+                "Collected job runner exit result"
+            );
+            event_bus.publish(SchedulerEvent::JobExecutionFinished {
+                job_id: result.job_id,
+                exit_code: result.exit_code,
+                signal: result.signal,
+            });
+        }
+
         // Sample time after building the Running-job snapshot so jobs that
         // started during snapshot construction don't look like future starts.
         let now = std::time::SystemTime::now();
 
-        // Check which jobs are zombies (no lock held)
+        // Check which jobs are zombies (no lock held). A result is authoritative
+        // even if the runner is in the short window before it exits.
         for (job_id, run_name, started_at) in running_jobs {
-            if !should_check_missing_session_as_zombie(started_at, now) {
+            if finished_ids.contains(&job_id)
+                || !should_check_missing_session_as_zombie(started_at, now)
+            {
                 continue;
             }
             if !executor.is_running(job_id, run_name.as_deref()) {
@@ -102,7 +133,9 @@ pub(super) async fn zombie_monitor_task(state: SharedState, event_bus: Arc<Event
     }
 }
 
-/// Zombie handler task - reacts to zombie events and marks jobs as failed
+/// Runner completion and zombie handler. A durable exit result is mapped to
+/// Finished/Failed through SchedulerRuntime so resource accounting, retries,
+/// dependencies, and executor cleanup all use the normal transition path.
 pub(super) async fn zombie_handler_task(
     mut events: tokio::sync::broadcast::Receiver<EventEnvelope>,
     state: SharedState,
@@ -111,31 +144,90 @@ pub(super) async fn zombie_handler_task(
     loop {
         match events.recv().await {
             Ok(event) => {
-                let handling_span = event.handling_span("zombie_handler");
+                let handling_span = event.handling_span("execution_result_handler");
                 let _entered = handling_span.enter();
-                let SchedulerEvent::ZombieJobDetected { job_id } = event.event else {
-                    continue;
+                let result = match event.event {
+                    SchedulerEvent::JobExecutionFinished {
+                        job_id,
+                        exit_code,
+                        signal,
+                    } => ExecutionResult {
+                        job_id,
+                        exit_code,
+                        signal,
+                    },
+                    SchedulerEvent::ZombieJobDetected { job_id } => ExecutionResult {
+                        job_id,
+                        exit_code: None,
+                        signal: None,
+                    },
+                    _ => continue,
                 };
 
-                // Update job state (write lock); executor cleanup runs inside
-                // fail_job (tmux: stop pipe-pane; process: no-op).
-                let result = {
-                    let mut state_guard = state.write().await;
-                    state_guard.fail_job(job_id).await
-                };
-                if let Some(Some(new_job_id)) = result {
-                    event_bus.publish(SchedulerEvent::JobSubmitted { job_id: new_job_id });
-                } else if result.is_some() {
-                    tracing::info!(job_id, "Marked zombie job as failed");
-                }
+                finalize_execution_result(&state, &event_bus, result).await;
             }
             Err(tokio::sync::broadcast::error::RecvError::Lagged(skipped)) => {
-                tracing::warn!(skipped, "Zombie handler lagged");
+                tracing::warn!(skipped, "Execution result handler lagged");
             }
             Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                tracing::info!("Event bus closed, zombie handler exiting");
+                tracing::info!("Event bus closed, execution result handler exiting");
                 break;
             }
+        }
+    }
+}
+
+async fn finalize_execution_result(
+    state: &SharedState,
+    event_bus: &Arc<EventBus>,
+    result: ExecutionResult,
+) {
+    let transition = {
+        let mut state_guard = state.write().await;
+        let Some(job) = state_guard.get_job(result.job_id) else {
+            return;
+        };
+        let gpu_ids = job.gpu_ids.clone();
+        let memory_mb = job.memory_limit_mb;
+
+        if result.succeeded() {
+            if state_guard.finish_job(result.job_id).await {
+                Some((JobState::Finished, gpu_ids, memory_mb, None))
+            } else {
+                None
+            }
+        } else {
+            state_guard
+                .fail_job(result.job_id)
+                .await
+                .map(|retry_job_id| (JobState::Failed, gpu_ids, memory_mb, retry_job_id))
+        }
+    };
+
+    if let Some((final_state, gpu_ids, memory_mb, retry_job_id)) = transition {
+        event_bus.publish(SchedulerEvent::JobCompleted {
+            job_id: result.job_id,
+            final_state,
+            gpu_ids,
+            memory_mb,
+        });
+        if let Some(new_job_id) = retry_job_id {
+            event_bus.publish(SchedulerEvent::JobSubmitted { job_id: new_job_id });
+        }
+
+        if final_state == JobState::Finished {
+            tracing::info!(
+                job_id = result.job_id,
+                exit_code = ?result.exit_code,
+                "Marked job finished from runner exit result"
+            );
+        } else {
+            tracing::info!(
+                job_id = result.job_id,
+                exit_code = ?result.exit_code,
+                signal = ?result.signal,
+                "Marked job failed from runner exit result"
+            );
         }
     }
 }

--- a/src/multicall/gflowd/scheduler_runtime/tests.rs
+++ b/src/multicall/gflowd/scheduler_runtime/tests.rs
@@ -12,6 +12,24 @@ impl Executor for NoopExecutor {
     }
 }
 
+struct CompletedExecutor {
+    result: ExecutionResult,
+}
+
+impl Executor for CompletedExecutor {
+    fn execute(&self, _job: &Job) -> anyhow::Result<()> {
+        Ok(())
+    }
+
+    fn execution_status(&self, job_id: u32, _run_name: Option<&str>) -> ExecutionStatus {
+        if self.result.job_id == job_id {
+            ExecutionStatus::Finished(self.result)
+        } else {
+            ExecutionStatus::Missing
+        }
+    }
+}
+
 #[test]
 fn formats_gpu_process_reasons() {
     assert_eq!(
@@ -22,6 +40,40 @@ fn formats_gpu_process_reasons() {
         format_unmanaged_process_reason(&[222, 333]),
         "unmanaged(pid=222,333)"
     );
+}
+
+#[tokio::test]
+async fn recovers_finished_running_job_from_executor_result() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut runtime = SchedulerRuntime::with_state_path(
+        Box::new(CompletedExecutor {
+            result: ExecutionResult {
+                job_id: 1,
+                exit_code: Some(0),
+                signal: None,
+            },
+        }),
+        dir.path().to_path_buf(),
+        None,
+        gflow::core::gpu_allocation::GpuAllocationStrategy::Sequential,
+        gflow::config::ProjectsConfig::default(),
+        gflow::config::FairShareConfig::default(),
+    )
+    .unwrap();
+
+    let job = Job::builder()
+        .command("echo recovered")
+        .submitted_by("recovery-test")
+        .build();
+    let (job_id, _, _) = runtime.submit_job(job).await.unwrap();
+    runtime.scheduler.prepare_jobs_for_execution();
+
+    let outcomes = runtime.recover_running_jobs().await;
+    assert_eq!(job_id, 1);
+    assert_eq!(outcomes.len(), 1);
+    assert_eq!(outcomes[0].job_id, job_id);
+    assert_eq!(outcomes[0].final_state, JobState::Finished);
+    assert_eq!(runtime.get_job(job_id).unwrap().state, JobState::Finished);
 }
 
 #[test]

--- a/src/multicall/gflowd/server.rs
+++ b/src/multicall/gflowd/server.rs
@@ -299,20 +299,27 @@ async fn create_shutdown_signal(state_saver: StateSaverHandle, executor: Arc<dyn
     // SIGHUP is delivered when the hosting tmux session is killed (`gflowd down`).
     let mut sighup = signal(SignalKind::hangup()).expect("Failed to register SIGHUP handler");
 
-    tokio::select! {
+    let terminate_jobs = tokio::select! {
         _ = sigterm.recv() => {
             tracing::info!(signal = "SIGTERM", "Initiating graceful shutdown");
+            true
         }
         _ = sigint.recv() => {
             tracing::info!(signal = "SIGINT", "Initiating graceful shutdown");
+            true
         }
         _ = sigusr2.recv() => {
-            tracing::info!(signal = "SIGUSR2", reload = true, "Initiating graceful shutdown");
+            // SIGUSR2 is the hot-reload handoff. The replacement daemon must
+            // be able to re-adopt runners, so the control plane exits without
+            // terminating execution entities.
+            tracing::info!(signal = "SIGUSR2", reload = true, "Initiating reload handoff");
+            false
         }
         _ = sighup.recv() => {
             tracing::info!(signal = "SIGHUP", "Initiating graceful shutdown");
+            true
         }
-    }
+    };
 
     // Save state before exiting
     tracing::info!("Saving state before shutdown");
@@ -322,7 +329,12 @@ async fn create_shutdown_signal(state_saver: StateSaverHandle, executor: Arc<dyn
         tracing::info!("State saved successfully");
     }
 
-    // Terminate managed job processes (process executor).
-    tracing::info!("Terminating managed job processes");
-    executor.shutdown();
+    if terminate_jobs {
+        // Explicit stop signals terminate managed job processes (process
+        // executor). A SIGUSR2 reload deliberately skips this step.
+        tracing::info!("Terminating managed job processes");
+        executor.shutdown();
+    } else {
+        tracing::info!("Leaving managed job runners alive for reload adoption");
+    }
 }

--- a/src/multicall/gflowd/server/handlers/events.rs
+++ b/src/multicall/gflowd/server/handlers/events.rs
@@ -93,6 +93,15 @@ fn event_payload(event: &SchedulerEvent) -> Option<(&'static str, serde_json::Va
         JobTimedOut { job_id, run_name } => {
             serde_json::json!({ "job_id": job_id, "run_name": run_name })
         }
+        JobExecutionFinished {
+            job_id,
+            exit_code,
+            signal,
+        } => serde_json::json!({
+            "job_id": job_id,
+            "exit_code": exit_code,
+            "signal": signal,
+        }),
         ZombieJobDetected { job_id } => serde_json::json!({ "job_id": job_id }),
         PeriodicHealthCheck => return None,
         ReservationCreated { reservation_id } => {

--- a/src/multicall/gflowd/webhooks.rs
+++ b/src/multicall/gflowd/webhooks.rs
@@ -518,6 +518,7 @@ pub(crate) async fn build_payloads(
         }
         SchedulerEvent::ManualGpuOverrideChanged { .. } => vec![],
         SchedulerEvent::MemoryAvailabilityChanged { .. }
+        | SchedulerEvent::JobExecutionFinished { .. }
         | SchedulerEvent::ZombieJobDetected { .. }
         | SchedulerEvent::PeriodicHealthCheck => vec![],
 

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -84,3 +84,19 @@ pub fn prepare_log_file_path(job_id: u32) -> anyhow::Result<PathBuf> {
 pub fn get_daemon_log_file_path() -> anyhow::Result<PathBuf> {
     Ok(get_log_dir()?.join("daemon.log"))
 }
+
+/// Directory containing durable execution metadata for process-backed jobs.
+///
+/// This is deliberately separate from scheduler state: the runner remains a
+/// valid source of truth while the daemon is offline.
+pub fn get_runner_dir() -> anyhow::Result<PathBuf> {
+    Ok(get_data_dir()?.join("runners"))
+}
+
+pub fn get_runner_metadata_path(job_id: u32) -> anyhow::Result<PathBuf> {
+    Ok(get_runner_dir()?.join(format!("{job_id}.json")))
+}
+
+pub fn get_runner_result_path(job_id: u32) -> anyhow::Result<PathBuf> {
+    Ok(get_runner_dir()?.join(format!("{job_id}.result.json")))
+}

--- a/tests/daemon_e2e_test.rs
+++ b/tests/daemon_e2e_test.rs
@@ -1017,19 +1017,11 @@ async fn log_content_and_events_endpoints_serve_dashboard() {
 
 // ── process-executor helpers ────────────────────────────────────────────────
 
-/// Find the pid of the `bash -c "… gcancel --finish <job_id> …"` wrapper for a
-/// process-executor job. Uses `pgrep -f` (matches the full command line) so it
-/// works on both Linux and macOS.
-fn find_job_wrapper_pid(job_id: u32) -> Option<u32> {
-    let needle = format!("gcancel --finish {job_id}");
-    let output = Command::new("pgrep").args(["-f", &needle]).output().ok()?;
-    if !output.status.success() {
-        return None;
-    }
-    String::from_utf8_lossy(&output.stdout)
-        .lines()
-        .filter_map(|line| line.trim().parse::<u32>().ok())
-        .next()
+/// Read the durable runner pid recorded for a process-executor job.
+fn find_job_runner_pid(data_dir: &Path, job_id: u32) -> Option<u32> {
+    let metadata_path = data_dir.join("runners").join(format!("{job_id}.json"));
+    let metadata: Value = serde_json::from_slice(&std::fs::read(metadata_path).ok()?).ok()?;
+    metadata["pid"].as_u64().map(|pid| pid as u32)
 }
 
 /// All pids whose process group id equals `pgid` (via `pgrep -g`).
@@ -1049,15 +1041,15 @@ fn processes_in_group(pgid: u32) -> Vec<u32> {
         .collect()
 }
 
-async fn wait_for_wrapper_pid(job_id: u32, timeout: Duration) -> u32 {
+async fn wait_for_runner_pid(data_dir: &Path, job_id: u32, timeout: Duration) -> u32 {
     let start = Instant::now();
     while start.elapsed() < timeout {
-        if let Some(pid) = find_job_wrapper_pid(job_id) {
+        if let Some(pid) = find_job_runner_pid(data_dir, job_id) {
             return pid;
         }
         tokio::time::sleep(Duration::from_millis(100)).await;
     }
-    panic!("timed out waiting for wrapper process of job {job_id}");
+    panic!("timed out waiting for runner process of job {job_id}");
 }
 
 async fn wait_for_process_group_gone(pgid: u32, timeout: Duration) {
@@ -1142,6 +1134,123 @@ async fn process_executor_runs_job_without_tmux() {
     sandbox.stop_daemon();
 }
 
+/// A reload handoff must preserve live runners and collect results written
+/// while the daemon is offline. This exercises the durable runner metadata
+/// rather than the old in-memory ProcessExecutor registry.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn process_executor_re_adopts_after_daemon_handoff() {
+    let Some(mut sandbox) = TestSandbox::new_direct("process") else {
+        return;
+    };
+    sandbox.start_daemon();
+    wait_for_health_status(&sandbox.base_url(), StatusCode::OK, Duration::from_secs(15)).await;
+
+    let client = gflow::Client::build(&sandbox.client_config()).unwrap();
+    let live_job = client
+        .add_job(
+            JobBuilder::new()
+                .submitted_by("re-adopt-e2e")
+                .run_dir(&sandbox.work_dir)
+                .command("sleep 8")
+                .build(),
+        )
+        .await
+        .unwrap();
+    let offline_job = client
+        .add_job(
+            JobBuilder::new()
+                .submitted_by("re-adopt-e2e")
+                .run_dir(&sandbox.work_dir)
+                .command("sleep 1")
+                .build(),
+        )
+        .await
+        .unwrap();
+
+    wait_for_job_state(
+        &client,
+        live_job.id,
+        JobState::Running,
+        Duration::from_secs(15),
+    )
+    .await;
+    wait_for_job_state(
+        &client,
+        offline_job.id,
+        JobState::Running,
+        Duration::from_secs(15),
+    )
+    .await;
+
+    let old_pid = sandbox
+        .daemon_child
+        .as_ref()
+        .expect("direct daemon child")
+        .id();
+    unsafe {
+        libc::kill(old_pid as libc::pid_t, libc::SIGUSR2);
+    }
+
+    let mut old_child = sandbox.daemon_child.take().unwrap();
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if old_child.try_wait().unwrap().is_some() {
+            break;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "old daemon did not exit on reload handoff"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    sandbox.daemon_started = false;
+
+    // The short runner should finish after the old daemon has exited, before
+    // the replacement starts.
+    let result_path = sandbox
+        .data_dir()
+        .join("runners")
+        .join(format!("{}.result.json", offline_job.id));
+    let result_deadline = Instant::now() + Duration::from_secs(10);
+    while !result_path.exists() {
+        assert!(
+            Instant::now() < result_deadline,
+            "offline runner did not persist its result"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    sandbox.start_daemon_direct();
+    sandbox.daemon_started = true;
+    wait_for_health_status(&sandbox.base_url(), StatusCode::OK, Duration::from_secs(15)).await;
+
+    let adopted = wait_for_job_state(
+        &client,
+        live_job.id,
+        JobState::Running,
+        Duration::from_secs(5),
+    )
+    .await;
+    assert_eq!(adopted.state, JobState::Running);
+
+    wait_for_job_state(
+        &client,
+        offline_job.id,
+        JobState::Finished,
+        Duration::from_secs(15),
+    )
+    .await;
+    wait_for_job_state(
+        &client,
+        live_job.id,
+        JobState::Finished,
+        Duration::from_secs(20),
+    )
+    .await;
+
+    sandbox.stop_daemon();
+}
+
 /// Acceptance: cancelling a job reliably terminates the whole process tree
 /// (SIGTERM to the process group, escalating to SIGKILL).
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1169,8 +1278,9 @@ async fn process_executor_cancel_terminates_process_tree() {
     )
     .await;
 
-    let wrapper_pid = wait_for_wrapper_pid(response.id, Duration::from_secs(10)).await;
-    // The wrapper is a session leader, so its pgid == its pid, and it has at
+    let wrapper_pid =
+        wait_for_runner_pid(&sandbox.data_dir(), response.id, Duration::from_secs(10)).await;
+    // The runner is a session leader, so its pgid == its pid, and it has at
     // least the two sleepers as group members.
     assert!(
         processes_in_group(wrapper_pid).len() >= 3,
@@ -1220,8 +1330,9 @@ async fn process_executor_detects_zombie_when_process_dies_without_reporting() {
     )
     .await;
 
-    // SIGKILL the whole process group so the wrapper's `gcancel` never runs.
-    let wrapper_pid = wait_for_wrapper_pid(response.id, Duration::from_secs(10)).await;
+    // SIGKILL the whole process group so the runner cannot record a result.
+    let wrapper_pid =
+        wait_for_runner_pid(&sandbox.data_dir(), response.id, Duration::from_secs(10)).await;
     unsafe {
         libc::kill(-(wrapper_pid as libc::pid_t), libc::SIGKILL);
     }


### PR DESCRIPTION
## Summary

- Add durable `setsid` runners with PID/PGID and process identity metadata plus atomic exit-result files.
- Re-adopt live runners and reconcile completed or missing runners during daemon startup and monitor polling.
- Collect process exit codes directly instead of relying on `gcancel --finish/--fail` for the process backend.
- Preserve runners across SIGUSR2 reload handoff while terminating them for explicit daemon shutdown signals.
- Add unit and daemon handoff coverage for adoption and completion during daemon downtime.

Tracked by Multica issue W-173.

## Testing

- `cargo test --manifest-path gflow/Cargo.toml` (407 passed, 3 ignored)
- `cargo test --manifest-path gflow/Cargo.toml --test daemon_e2e_test process_executor_ -- --nocapture` (4 passed)
- `cargo check --manifest-path gflow/Cargo.toml`
- `cargo check --manifest-path gflow/Cargo.toml --features metrics`
- `cargo clippy --manifest-path gflow/Cargo.toml --all-targets -- -D warnings`
- `cargo fmt --manifest-path gflow/Cargo.toml -- --check`
