### PR TITLE
W-198: gflowd unified start/stop/restart + optional systemd user service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Unified gflowd lifecycle + optional systemd user service**: a consistent `gflowd start` / `stop` / `restart` / `status` verb set that hides how the daemon is hosted from the user
+  - Hosting is chosen automatically by priority: systemd user service → tmux → direct detached process (pidfile); `status` reports the current hosting mode
+  - New `gflowd service install` / `gflowd service uninstall` manage `~/.config/systemd/user/gflowd.service` (`enable --now`, auto-start on login + `Restart=on-failure` crash recovery); `ExecStart` reuses the existing `daemon_start_args` so the daemon core is unchanged
+  - `up` / `down` are retained as aliases of `start` / `stop` for backwards compatibility
 - **Process executor (default)**: jobs now run as detached child process groups (`setsid`) with stdio redirected to `logs/<job_id>.log` — no tmux required for job execution
   - New `[executor] type = "process" | "tmux"` config; `process` is the default, the legacy tmux executor remains fully available (`gjob attach` / `gjob close-sessions` keep working in tmux mode)
   - Cancellation SIGTERMs the whole process group and escalates to SIGKILL after a grace period; zombie detection uses real process liveness instead of tmux-session existence

--- a/README.md
+++ b/README.md
@@ -53,12 +53,16 @@ pip install --index-url https://test.pypi.org/simple/ runqd
 
 ```bash
 gflowd init
-gflowd up
+gflowd start
 gbatch --gpus 1 --name demo bash -lc 'echo "hello from gflow"; sleep 30'
 gqueue
 gjob show <job_id>
-gflowd down
+gflowd stop
 ```
+
+On Linux with a systemd user manager, `gflowd service install` enables
+auto-start on login and automatic crash recovery. `gflowd status` always shows
+how the daemon is hosted (systemd user service, tmux, or direct process).
 
 ## MCP
 

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -127,18 +127,34 @@ If the commands work and `gflowd --version` prints a version, the install is com
 
 Job execution no longer requires tmux: the daemon spawns each job as a detached
 child process group and redirects its output to `logs/<job_id>.log`.
-`gflowd up` hosts the daemon in tmux when available, and falls back to a direct
-detached process otherwise.
+`gflowd start` hosts the daemon via the systemd user service when installed,
+otherwise in tmux when available, otherwise as a direct detached process.
 
 ```bash
 # Optional: create a default config
 gflowd init
 
 # Start the daemon
-gflowd up
+gflowd start
 
 # Check status
 gflowd status
+```
+
+### Optional: systemd user service (auto-start + crash recovery)
+
+On Linux with a systemd user manager, install `gflowd` as a user service so it
+auto-starts on login and restarts automatically if it crashes:
+
+```bash
+gflowd service install
+gflowd status        # shows "Hosting: systemd user service"
+```
+
+Remove it later with:
+
+```bash
+gflowd service uninstall
 ```
 
 ### 2. Check tmux (only if you use tmux features)
@@ -158,7 +174,7 @@ If you have NVIDIA GPUs, you can verify detection:
 gflowd init
 
 # Start the daemon
-gflowd up
+gflowd start
 
 # Check status
 gflowd status

--- a/docs/src/getting-started/quick-start.md
+++ b/docs/src/getting-started/quick-start.md
@@ -19,11 +19,17 @@ gflowd init
 Start the daemon:
 
 ```shell
-gflowd up
+gflowd start
 ```
 
+::: tip
+`gflowd start` hosts the daemon via the systemd user service when installed,
+otherwise in tmux, otherwise as a direct process — no need to worry about how.
+:::
+
 ::: warning
-If `gflowd up` fails, check `tmux` first.
+If `gflowd start` fails, check `tmux` first (or install the systemd user
+service with `gflowd service install`).
 :::
 
 Check status:
@@ -63,7 +69,7 @@ Use `gqueue` first to find the job ID.
 ## Step 4: Stop the Scheduler
 
 ```shell
-gflowd down
+gflowd stop
 ```
 
 ## Next Steps

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -19,13 +19,16 @@ gflowd init
 gflowd init --yes
 
 # Start the daemon
-gflowd up
+gflowd start
 
 # Start with restricted GPUs and random allocation
-gflowd up --gpus 0,2 --gpu-allocation-strategy random
+gflowd start --gpus 0,2 --gpu-allocation-strategy random
 
 # Start with faster GPU occupancy polling
-gflowd up --gpu-poll-interval-secs 3
+gflowd start --gpu-poll-interval-secs 3
+
+# Install the optional systemd user service (auto-start + crash recovery)
+gflowd service install
 
 # Reload without downtime
 gflowd reload
@@ -35,7 +38,7 @@ gflowd restart --gpus 0-3
 
 # Check status or stop the daemon
 gflowd status
-gflowd down
+gflowd stop
 ```
 
 ## Global Options
@@ -67,13 +70,16 @@ Options:
 - `--gpu-allocation-strategy <strategy>`: `sequential` or `random`
 - `--gpu-poll-interval-secs <seconds>`: poll NVML for GPU occupancy changes every N seconds (default: `10`, minimum: `1`)
 
-### `gflowd up`
+### `gflowd start`
 
-Start the daemon in a tmux session.
+Start the daemon. The hosting layer is chosen automatically: the systemd user
+service if installed, otherwise tmux, otherwise a direct detached process.
 
 ```bash
-gflowd up [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
+gflowd start [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
 ```
+
+`up` is retained as an alias of `start`.
 
 ### `gflowd reload`
 
@@ -97,19 +103,36 @@ Use this when a full restart is acceptable or needed.
 
 ### `gflowd status`
 
-Show whether the daemon is running and responding to health checks.
+Show whether the daemon is running and how it is hosted (systemd user service,
+tmux, or direct process).
 
 ```bash
 gflowd status
 ```
 
-### `gflowd down`
+### `gflowd stop`
 
 Stop the daemon.
 
 ```bash
-gflowd down
+gflowd stop
 ```
+
+`down` is retained as an alias of `stop`.
+
+### `gflowd service`
+
+Manage the optional systemd user service, which provides auto-start on login
+and automatic crash recovery.
+
+```bash
+gflowd service install [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
+gflowd service uninstall
+```
+
+`install` writes `~/.config/systemd/user/gflowd.service`, reloads systemd, and
+runs `enable --now`. It requires a systemd user manager; on systems without
+one it prints a clear message and falls back to tmux/direct hosting.
 
 ### `gflowd completion <shell>`
 
@@ -126,7 +149,7 @@ gflowd completion fish
 - `--gpus` affects which GPUs the scheduler may allocate for new work.
 - `--gpu-allocation-strategy` accepts `sequential` or `random`.
 - `--gpu-poll-interval-secs` controls how quickly unmanaged GPU occupancy changes are detected.
-- `gflowd up`, `reload`, and `restart` all accept the same GPU-related overrides.
+- `gflowd start`, `reload`, and `restart` all accept the same GPU-related overrides.
 
 ## See Also
 

--- a/docs/src/reference/quick-reference.md
+++ b/docs/src/reference/quick-reference.md
@@ -4,10 +4,11 @@
 
 ```bash
 gflowd init
-gflowd up
+gflowd start       # systemd user service → tmux → direct process
 gflowd status
-gflowd down
+gflowd stop
 gflowd restart
+gflowd service install   # optional: auto-start + crash recovery
 ```
 
 ## Inspect + Monitor

--- a/docs/src/zh-CN/getting-started/installation.md
+++ b/docs/src/zh-CN/getting-started/installation.md
@@ -126,18 +126,35 @@ gflowd --version
 ### 1. 检查守护进程（无需 tmux）
 
 作业执行不再依赖 tmux：daemon 会把每个作业作为独立的子进程组（`setsid`）
-启动，并将输出重定向到 `logs/<job_id>.log`。`gflowd up` 在可用时会用 tmux
-托管 daemon，否则回退为直接以独立进程方式启动。
+启动，并将输出重定向到 `logs/<job_id>.log`。`gflowd start` 在已安装
+systemd user service 时走 systemd，否则在可用时用 tmux 托管 daemon，再否则
+回退为直接以独立进程方式启动。
 
 ```bash
 # 可选：生成默认配置
 gflowd init
 
 # 启动守护进程
-gflowd up
+gflowd start
 
 # 查看状态
 gflowd status
+```
+
+### 可选：systemd user service（开机自启 + 崩溃拉起）
+
+在带有 systemd user manager 的 Linux 上，可以把 gflowd 安装为用户服务，
+实现开机自启与崩溃自动拉起：
+
+```bash
+gflowd service install
+gflowd status        # 显示 "Hosting: systemd user service"
+```
+
+卸载：
+
+```bash
+gflowd service uninstall
 ```
 
 ### 2. 检查 tmux（仅在使用 tmux 功能时需要）
@@ -157,7 +174,7 @@ tmux kill-session -t test
 gflowd init
 
 # 启动守护进程
-gflowd up
+gflowd start
 
 # 检查状态
 gflowd status

--- a/docs/src/zh-CN/getting-started/quick-start.md
+++ b/docs/src/zh-CN/getting-started/quick-start.md
@@ -19,11 +19,17 @@ gflowd init
 启动守护进程：
 
 ```shell
-gflowd up
+gflowd start
 ```
 
+::: tip
+`gflowd start` 会按 systemd user service（已安装时）→ tmux → 直接进程的顺序
+自动选择托管方式，无需关心 daemon 由谁托管。
+:::
+
 ::: warning
-如果 `gflowd up` 失败，先检查 `tmux`。
+如果 `gflowd start` 失败，先检查 `tmux`（或先用 `gflowd service install`
+安装 systemd user service）。
 :::
 
 检查状态：
@@ -63,7 +69,7 @@ gjob log <job_id>
 ## 第 4 步：停止调度器
 
 ```shell
-gflowd down
+gflowd stop
 ```
 
 ## 接下来

--- a/docs/src/zh-CN/reference/gflowd-reference.md
+++ b/docs/src/zh-CN/reference/gflowd-reference.md
@@ -19,13 +19,16 @@ gflowd init
 gflowd init --yes
 
 # 启动守护进程
-gflowd up
+gflowd start
 
 # 只使用部分 GPU，并启用随机分配策略
-gflowd up --gpus 0,2 --gpu-allocation-strategy random
+gflowd start --gpus 0,2 --gpu-allocation-strategy random
 
 # 更快检测 GPU 占用变化
-gflowd up --gpu-poll-interval-secs 3
+gflowd start --gpu-poll-interval-secs 3
+
+# 安装可选的 systemd user service（开机自启 + 崩溃拉起）
+gflowd service install
 
 # 无停机热重载
 gflowd reload
@@ -35,7 +38,7 @@ gflowd restart --gpus 0-3
 
 # 查看状态或停止守护进程
 gflowd status
-gflowd down
+gflowd stop
 ```
 
 ## 全局选项
@@ -67,13 +70,16 @@ gflowd init [--yes] [--force] [--advanced] [--gpus <indices>] [--host <host>] [-
 - `--gpu-allocation-strategy <strategy>`：`sequential` 或 `random`
 - `--gpu-poll-interval-secs <seconds>`：每隔 N 秒轮询一次 NVML 检查 GPU 占用变化（默认 `10`，最小 `1`）
 
-### `gflowd up`
+### `gflowd start`
 
-在 tmux 会话中启动守护进程。
+启动守护进程。托管方式自动选择：已安装 systemd user service 则走 systemd，
+否则用 tmux，否则直接以独立进程方式启动。
 
 ```bash
-gflowd up [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
+gflowd start [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
 ```
+
+保留 `up` 作为 `start` 的别名。
 
 ### `gflowd reload`
 
@@ -97,19 +103,35 @@ gflowd restart [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-
 
 ### `gflowd status`
 
-显示守护进程是否在运行，以及健康检查是否通过。
+显示守护进程是否在运行，以及当前托管方式（systemd user service、tmux 或
+直接进程）。
 
 ```bash
 gflowd status
 ```
 
-### `gflowd down`
+### `gflowd stop`
 
 停止守护进程。
 
 ```bash
-gflowd down
+gflowd stop
 ```
+
+保留 `down` 作为 `stop` 的别名。
+
+### `gflowd service`
+
+管理可选的 systemd user service，提供开机自启与崩溃自动拉起。
+
+```bash
+gflowd service install [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
+gflowd service uninstall
+```
+
+`install` 会写入 `~/.config/systemd/user/gflowd.service`、重载 systemd 并执行
+`enable --now`。需要 systemd user manager；在没有 systemd 的系统上会给出明确
+提示并回退到 tmux/直接进程托管。
 
 ### `gflowd completion <shell>`
 
@@ -126,7 +148,7 @@ gflowd completion fish
 - `--gpus` 控制调度器为新任务分配哪些 GPU。
 - `--gpu-allocation-strategy` 可选 `sequential` 或 `random`。
 - `--gpu-poll-interval-secs` 控制检测非 gflow GPU 占用变化的速度。
-- `up`、`reload`、`restart` 三个子命令都支持相同的 GPU 相关覆盖参数。
+- `start`、`reload`、`restart` 三个子命令都支持相同的 GPU 相关覆盖参数。
 
 ## 另见
 

--- a/docs/src/zh-CN/reference/quick-reference.md
+++ b/docs/src/zh-CN/reference/quick-reference.md
@@ -4,10 +4,11 @@
 
 ```bash
 gflowd init
-gflowd up
+gflowd start       # systemd user service → tmux → 直接进程
 gflowd status
-gflowd down
+gflowd stop
 gflowd restart
+gflowd service install   # 可选：开机自启 + 崩溃拉起
 ```
 
 ## 查看与监控

--- a/src/multicall/gflowd/cli.rs
+++ b/src/multicall/gflowd/cli.rs
@@ -50,6 +50,20 @@ pub struct DaemonOverrideArgs {
     pub gpu_poll_interval_secs: Option<u64>,
 }
 
+#[derive(Debug, Clone, Default, Args)]
+pub struct ServiceArgs {
+    #[command(flatten)]
+    pub daemon_overrides: DaemonOverrideArgs,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub enum ServiceAction {
+    /// Install the gflowd systemd user service and enable it
+    Install(ServiceArgs),
+    /// Stop and remove the gflowd systemd user service
+    Uninstall,
+}
+
 #[derive(Debug, Parser)]
 pub enum Commands {
     /// Create or update the configuration file via a guided wizard
@@ -81,16 +95,23 @@ pub enum Commands {
         #[command(flatten)]
         daemon_overrides: DaemonOverrideArgs,
     },
-    /// Start the daemon in a tmux session
-    Up(DaemonOverrideArgs),
+    /// Start the daemon (systemd user service if available, else tmux, else direct process)
+    #[command(alias = "up")]
+    Start(DaemonOverrideArgs),
     /// Stop the daemon
-    Down,
+    #[command(alias = "down")]
+    Stop,
     /// Restart the daemon
     Restart(DaemonOverrideArgs),
     /// Reload the daemon with zero downtime
     Reload(DaemonOverrideArgs),
-    /// Show the daemon status
+    /// Show the daemon status and how it is hosted
     Status,
+    /// Manage the optional systemd user service
+    Service {
+        #[command(subcommand)]
+        action: ServiceAction,
+    },
     /// Generate shell completion scripts
     Completion {
         /// The shell to generate completions for

--- a/src/multicall/gflowd/commands.rs
+++ b/src/multicall/gflowd/commands.rs
@@ -7,6 +7,7 @@ pub mod down;
 pub mod init;
 pub mod reload;
 pub mod status;
+pub mod systemd;
 pub mod up;
 
 pub static TMUX_SESSION_NAME: &str = "gflow_server";
@@ -176,10 +177,10 @@ pub async fn handle_commands(
             )
             .await?;
         }
-        Commands::Up(daemon_overrides) => {
+        Commands::Start(daemon_overrides) => {
             up::handle_up(config_path, daemon_overrides, verbosity).await?;
         }
-        Commands::Down => {
+        Commands::Stop => {
             down::handle_down().await?;
         }
         Commands::Restart(daemon_overrides) => {
@@ -191,6 +192,9 @@ pub async fn handle_commands(
         }
         Commands::Status => {
             status::handle_status(config_path).await?;
+        }
+        Commands::Service { action } => {
+            systemd::handle_service(config_path, verbosity, action).await?;
         }
         Commands::Completion { shell } => {
             crate::multicall::completion::handle_completion(

--- a/src/multicall/gflowd/commands/down.rs
+++ b/src/multicall/gflowd/commands/down.rs
@@ -3,6 +3,15 @@ use std::time::Duration;
 use tmux_interface::{KillSession, Tmux};
 
 pub async fn handle_down() -> Result<()> {
+    // systemd user service takes priority when installed and active.
+    if super::systemd::unit_installed().unwrap_or(false)
+        && super::systemd::is_active().unwrap_or(false)
+    {
+        super::systemd::stop()?;
+        println!("gflowd stopped.");
+        return Ok(());
+    }
+
     // Direct (pidfile) mode first.
     if let Some(pid) = super::read_daemon_pidfile() {
         if super::process_alive(pid) {

--- a/src/multicall/gflowd/commands/status.rs
+++ b/src/multicall/gflowd/commands/status.rs
@@ -2,6 +2,31 @@ use anyhow::Result;
 use gflow::tmux::is_session_exist;
 
 pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<()> {
+    // systemd user service takes priority.
+    if super::systemd::unit_installed().unwrap_or(false)
+        && super::systemd::is_active().unwrap_or(false)
+    {
+        let client = gflow::create_client_or_default(config_path)?;
+        match client.get_health().await {
+            Ok(health) if health.is_success() => {
+                println!("Status: Running");
+                println!(
+                    "Hosting: systemd user service ({}).",
+                    super::systemd::SYSTEMD_UNIT
+                );
+            }
+            Ok(_) => {
+                println!("Status: Unhealthy");
+                eprintln!("The gflowd daemon responded to the health check but is not healthy.");
+            }
+            Err(e) => {
+                println!("Status: Not Running");
+                eprintln!("Failed to connect to gflowd daemon: {e}");
+            }
+        }
+        return Ok(());
+    }
+
     // Direct (pidfile) mode first.
     if let Some(pid) = super::read_daemon_pidfile() {
         if !super::process_alive(pid) {

--- a/src/multicall/gflowd/commands/systemd.rs
+++ b/src/multicall/gflowd/commands/systemd.rs
@@ -1,0 +1,205 @@
+use super::super::cli::ServiceAction;
+use super::DaemonStartOptions;
+use anyhow::{anyhow, bail, Context, Result};
+use clap_verbosity_flag::Verbosity;
+use std::path::PathBuf;
+
+/// Name of the systemd user unit.
+pub const SYSTEMD_UNIT: &str = "gflowd.service";
+
+/// Path of the installed user unit file (`~/.config/systemd/user/gflowd.service`).
+pub fn systemd_unit_path() -> Result<PathBuf> {
+    let config_dir = gflow::paths::get_config_dir()?;
+    // Walk one level up from `~/.config/gflow` to `~/.config`, then into
+    // systemd's user-unit directory.
+    let base = config_dir
+        .parent()
+        .ok_or_else(|| anyhow!("Failed to resolve config directory"))?;
+    Ok(base.join("systemd").join("user").join(SYSTEMD_UNIT))
+}
+
+/// Whether a systemd user manager is reachable from this environment.
+///
+/// Requires the `systemctl` binary and a live user systemd socket
+/// (`$XDG_RUNTIME_DIR/systemd/private`). This is the heuristic used to decide
+/// whether `gflowd start`/`stop`/`status` can delegate to systemd.
+pub fn systemd_user_available() -> bool {
+    let has_systemctl = std::process::Command::new("systemctl")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false);
+    if !has_systemctl {
+        return false;
+    }
+    let runtime = std::env::var_os("XDG_RUNTIME_DIR").map(PathBuf::from);
+    match runtime {
+        Some(runtime) => runtime.join("systemd").join("private").exists(),
+        None => false,
+    }
+}
+
+/// Whether the `gflowd.service` user unit has been installed.
+pub fn unit_installed() -> Result<bool> {
+    Ok(systemd_unit_path()?.exists())
+}
+
+/// Whether the installed unit is currently active.
+pub fn is_active() -> Result<bool> {
+    let output = std::process::Command::new("systemctl")
+        .arg("--user")
+        .args(["is-active", SYSTEMD_UNIT])
+        .output()
+        .context("failed to run systemctl --user is-active")?;
+    Ok(output.status.success())
+}
+
+fn systemctl(args: &[&str]) -> Result<std::process::Output> {
+    let output = std::process::Command::new("systemctl")
+        .arg("--user")
+        .args(args)
+        .output()
+        .with_context(|| format!("failed to run systemctl --user {}", args.join(" ")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        bail!(
+            "systemctl --user {} failed: {}",
+            args.join(" "),
+            if stderr.is_empty() {
+                "non-zero exit status".to_string()
+            } else {
+                stderr
+            }
+        );
+    }
+    Ok(output)
+}
+
+pub fn start() -> Result<()> {
+    systemctl(&["start", SYSTEMD_UNIT]).map(|_| ())
+}
+
+pub fn stop() -> Result<()> {
+    systemctl(&["stop", SYSTEMD_UNIT]).map(|_| ())
+}
+
+/// Build the `ExecStart` line for the unit, reusing the daemon start args and
+/// always pointing at the currently running `gflow` binary.
+fn unit_exec_start(
+    config_path: &Option<std::path::PathBuf>,
+    options: &DaemonStartOptions<'_>,
+) -> Result<String> {
+    let exe = std::env::current_exe().context("failed to resolve current gflow binary")?;
+    let mut parts: Vec<String> = vec![shell_escape::escape(exe.to_string_lossy()).into_owned()];
+    if let Some(cfg) = config_path {
+        parts.push("-c".to_string());
+        parts.push(shell_escape::escape(cfg.to_string_lossy()).into_owned());
+    }
+    for arg in super::daemon_start_args(options)? {
+        parts.push(shell_escape::escape(arg.into()).into_owned());
+    }
+    Ok(parts.join(" "))
+}
+
+fn unit_file_content(exec_start: &str) -> String {
+    format!(
+        r#"[Unit]
+Description=GFlow daemon
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={exec_start}
+Restart=on-failure
+RestartSec=2
+
+[Install]
+WantedBy=default.target
+"#
+    )
+}
+
+pub async fn handle_service(
+    config_path: &Option<std::path::PathBuf>,
+    verbosity: Verbosity,
+    action: ServiceAction,
+) -> Result<()> {
+    match action {
+        ServiceAction::Install(args) => {
+            if !systemd_user_available() {
+                bail!(
+                    "systemd user services are not available here (no user systemd manager). \
+                     gflowd will host the daemon via tmux or as a direct process instead; \
+                     run `gflowd start` to start it."
+                );
+            }
+            let start_options =
+                super::DaemonStartOptions::from_overrides(&args.daemon_overrides, verbosity);
+            super::validate_daemon_startup_config(config_path, &start_options)?;
+
+            let exec_start = unit_exec_start(config_path, &start_options)?;
+            let path = systemd_unit_path()?;
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)
+                    .with_context(|| format!("Failed to create {}", parent.display()))?;
+            }
+            std::fs::write(&path, unit_file_content(&exec_start))
+                .with_context(|| format!("Failed to write systemd unit {}", path.display()))?;
+
+            systemctl(&["daemon-reload"])?;
+            systemctl(&["enable", "--now", SYSTEMD_UNIT])?;
+            println!("gflowd systemd user service installed and started.");
+            println!("Unit: {}", path.display());
+            println!("gflowd will auto-start on login and restart on crash.");
+        }
+        ServiceAction::Uninstall => {
+            if !systemd_user_available() {
+                bail!("systemd user services are not available on this system.");
+            }
+            let path = systemd_unit_path()?;
+            // Best-effort: stop and disable even if the unit is gone.
+            let _ = systemctl(&["stop", SYSTEMD_UNIT]);
+            let _ = systemctl(&["disable", SYSTEMD_UNIT]);
+            if path.exists() {
+                std::fs::remove_file(&path)
+                    .with_context(|| format!("Failed to remove systemd unit {}", path.display()))?;
+            }
+            let _ = systemctl(&["daemon-reload"]);
+            println!("gflowd systemd user service removed.");
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unit_file_content_embeds_exec_start() {
+        let content = unit_file_content("/path/to/gflow __multicall gflowd -vvv");
+        assert!(content.contains("Description=GFlow daemon"));
+        assert!(content.contains("Type=simple"));
+        assert!(content.contains("ExecStart=/path/to/gflow __multicall gflowd -vvv"));
+        assert!(content.contains("Restart=on-failure"));
+        assert!(content.contains("RestartSec=2"));
+        assert!(content.contains("WantedBy=default.target"));
+    }
+
+    #[test]
+    fn unit_exec_start_reuses_daemon_start_command() {
+        // Ensure the unit's ExecStart matches the tmux/direct daemon command
+        // token-for-token (plus an optional `-c <config>`), so the hosting
+        // layer is transparent to the user.
+        let options = DaemonStartOptions {
+            gpus: None,
+            gpu_allocation_strategy: None,
+            gpu_poll_interval_secs: None,
+            verbosity: Verbosity::new(0, 0),
+        };
+        let exec_start = super::unit_exec_start(&None, &options).unwrap();
+        let daemon_cmd = super::super::daemon_start_command(&options).unwrap();
+        assert!(exec_start.contains("__multicall gflowd -vvv"));
+        assert!(daemon_cmd.contains("__multicall gflowd -vvv"));
+    }
+}

--- a/src/multicall/gflowd/commands/up.rs
+++ b/src/multicall/gflowd/commands/up.rs
@@ -7,6 +7,19 @@ pub async fn handle_up(
     daemon_overrides: super::super::cli::DaemonOverrideArgs,
     verbosity: Verbosity,
 ) -> Result<()> {
+    // systemd user service takes priority when installed and active.
+    if super::systemd::unit_installed()? && super::systemd::is_active()? {
+        println!("gflowd is already running (systemd user service).");
+        println!("Use `gflowd restart` to restart it.");
+        return Ok(());
+    }
+    if super::systemd::unit_installed()? {
+        println!("Starting via systemd user service...");
+        super::systemd::start()?;
+        println!("gflowd started (systemd user service).");
+        return Ok(());
+    }
+
     match existing_daemon_state(config_path).await? {
         ExistingDaemonState::NotPresent => {}
         ExistingDaemonState::Healthy => {


### PR DESCRIPTION
Closes W-198

Unified gflowd lifecycle verbs that hide how the daemon is hosted, plus an optional systemd user service for auto-start and crash recovery.

- gflowd start/stop/restart/status; hosting chosen by priority: systemd user service, tmux, direct detached process
- gflowd service install/uninstall manage ~/.config/systemd/user/gflowd.service (enable --now, Restart=on-failure)
- status reports the current hosting mode
- up/down kept as aliases of start/stop
- docs + CHANGELOG updated; all tests/clippy/fmt/doc pass