### PR TITLE
feat(gflowd): flock lock + identity check for direct-process hosting (W-199)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,12 +62,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     start time), mirroring the process executor's existing guard; `down` and
     `restart` re-verify the identity right before signalling, so a PID that was
     recycled to an unrelated process is never SIGTERM/SIGKILLed
-  - The legacy plain-PID `gflowd.pid` is still honored so daemons started by
-    older builds can be stopped, but only when the process is verifiably a gflow
-    daemon; otherwise it is treated as stale and cleaned up
   - The directly-hosted daemon takes the lock itself (internal
     `--direct-internal` flag), so a duplicate `gflowd up` is refused even if the
     liveness probe raced
+  - The old plain-PID `gflowd.pid` is no longer written or read
 
 - **Job State Transitions**: Updated to support new `Timeout` state
   - Added `Running → Timeout` transition for time limit violations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependency Shorthand**: `gbatch --depends-on` now accepts `@` (last) and `@~N` (Nth from the end) to reference recent submissions without copying job IDs
 
 ### Changed
+- **Direct-process daemon hosting hardened against PID reuse**: `gflowd`'s
+  no-tmux hosting now uses an exclusive `flock` on a `gflowd.lock` file as the
+  mutual-exclusion and liveness signal, instead of a bare `gflowd.pid`
+  (`src/multicall/gflowd/commands/lifecycle.rs`)
+  - The lock is auto-released by the kernel when the daemon crashes, so there
+    is no stale-pidfile ambiguity; `status`/`down`/`restart` treat a released
+    lock as "not running" and clean up stale lock/pid files
+  - The lock file body records the daemon identity (`pid` + `pgid` + process
+    start time), mirroring the process executor's existing guard; `down` and
+    `restart` re-verify the identity right before signalling, so a PID that was
+    recycled to an unrelated process is never SIGTERM/SIGKILLed
+  - The legacy plain-PID `gflowd.pid` is still honored so daemons started by
+    older builds can be stopped, but only when the process is verifiably a gflow
+    daemon; otherwise it is treated as stale and cleaned up
+  - The directly-hosted daemon takes the lock itself (internal
+    `--direct-internal` flag), so a duplicate `gflowd up` is refused even if the
+    liveness probe raced
+
 - **Job State Transitions**: Updated to support new `Timeout` state
   - Added `Running → Timeout` transition for time limit violations
   - Updated state transition validation logic

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -156,7 +156,8 @@ gflowd completion fish
   is released automatically when the daemon exits, so `status` never reports a
   stale instance. The lock file also records the daemon's identity (`pid` +
   `pgid` + process start time); `down`/`restart` verify it before signalling so
-  a recycled PID is never SIGTERM/SIGKILLed.
+  a recycled PID is never SIGTERM/SIGKILLed. This replaces the older plain-PID
+  `gflowd.pid`, which is no longer written or read.
 
 ## See Also
 

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -150,6 +150,13 @@ gflowd completion fish
 - `--gpu-allocation-strategy` accepts `sequential` or `random`.
 - `--gpu-poll-interval-secs` controls how quickly unmanaged GPU occupancy changes are detected.
 - `gflowd start`, `reload`, and `restart` all accept the same GPU-related overrides.
+- In direct-process mode (no systemd, no tmux), the daemon holds an exclusive
+  `flock` on `gflowd.lock` in the runtime directory. The lock is both mutual
+  exclusion (a duplicate `up` is refused) and a crash-safe liveness signal: it
+  is released automatically when the daemon exits, so `status` never reports a
+  stale instance. The lock file also records the daemon's identity (`pid` +
+  `pgid` + process start time); `down`/`restart` verify it before signalling so
+  a recycled PID is never SIGTERM/SIGKILLed.
 
 ## See Also
 

--- a/docs/src/zh-CN/reference/gflowd-reference.md
+++ b/docs/src/zh-CN/reference/gflowd-reference.md
@@ -149,6 +149,12 @@ gflowd completion fish
 - `--gpu-allocation-strategy` 可选 `sequential` 或 `random`。
 - `--gpu-poll-interval-secs` 控制检测非 gflow GPU 占用变化的速度。
 - `start`、`reload`、`restart` 三个子命令都支持相同的 GPU 相关覆盖参数。
+- 在直接进程托管模式（无 systemd、无 tmux）下，daemon 会在运行时目录对
+  `gflowd.lock` 持有排他 `flock`。该锁既是互斥信号（重复 `up` 会被拒绝），
+  也是崩溃安全的存活信号：daemon 退出时锁会自动释放，因此 `status` 不会误报
+  残留实例。锁文件同时记录 daemon 身份（`pid` + `pgid` + 进程启动时间）；
+  `down`/`restart` 在发信号前会校验身份，从而绝不会对已被复用的 PID 误发
+  SIGTERM/SIGKILL。
 
 ## 另见
 

--- a/docs/src/zh-CN/reference/gflowd-reference.md
+++ b/docs/src/zh-CN/reference/gflowd-reference.md
@@ -154,7 +154,7 @@ gflowd completion fish
   也是崩溃安全的存活信号：daemon 退出时锁会自动释放，因此 `status` 不会误报
   残留实例。锁文件同时记录 daemon 身份（`pid` + `pgid` + 进程启动时间）；
   `down`/`restart` 在发信号前会校验身份，从而绝不会对已被复用的 PID 误发
-  SIGTERM/SIGKILL。
+  SIGTERM/SIGKILL。这取代了旧的纯 PID `gflowd.pid`，后者不再写入或读取。
 
 ## 另见
 

--- a/src/multicall/gflowd/cli.rs
+++ b/src/multicall/gflowd/cli.rs
@@ -31,6 +31,11 @@ pub struct GFlowd {
     #[arg(long, hide = true)]
     pub gpu_poll_interval_secs_internal: Option<u64>,
 
+    /// Mark this daemon as directly-hosted (no tmux/systemd). The daemon
+    /// holds an exclusive flock on the daemon lock file for its lifetime.
+    #[arg(long, hide = true)]
+    pub direct_internal: bool,
+
     #[command(flatten)]
     pub verbosity: Verbosity,
 }

--- a/src/multicall/gflowd/commands.rs
+++ b/src/multicall/gflowd/commands.rs
@@ -5,41 +5,13 @@ use clap_verbosity_flag::{Verbosity, VerbosityFilter};
 
 pub mod down;
 pub mod init;
+pub mod lifecycle;
 pub mod reload;
 pub mod status;
 pub mod systemd;
 pub mod up;
 
 pub static TMUX_SESSION_NAME: &str = "gflow_server";
-
-/// Path of the pidfile used when the daemon is hosted without tmux.
-pub fn daemon_pidfile_path() -> anyhow::Result<std::path::PathBuf> {
-    Ok(gflow::paths::get_runtime_dir()?.join("gflowd.pid"))
-}
-
-pub fn read_daemon_pidfile() -> Option<u32> {
-    let content = std::fs::read_to_string(daemon_pidfile_path().ok()?).ok()?;
-    content.trim().parse().ok()
-}
-
-pub fn write_daemon_pidfile(pid: u32) -> anyhow::Result<()> {
-    let path = daemon_pidfile_path()?;
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    std::fs::write(&path, pid.to_string())?;
-    Ok(())
-}
-
-pub fn remove_daemon_pidfile() {
-    if let Ok(path) = daemon_pidfile_path() {
-        let _ = std::fs::remove_file(path);
-    }
-}
-
-pub fn process_alive(pid: u32) -> bool {
-    unsafe { libc::kill(pid as libc::pid_t, 0) == 0 }
-}
 
 #[derive(Debug, Clone)]
 pub struct DaemonStartOptions<'a> {

--- a/src/multicall/gflowd/commands/down.rs
+++ b/src/multicall/gflowd/commands/down.rs
@@ -19,8 +19,7 @@ pub async fn handle_down() -> Result<()> {
         // signalled (flock auto-released on crash; identity check on reuse).
         if !super::lifecycle::verify_before_signal(pid) {
             super::lifecycle::remove_daemon_lock();
-            super::lifecycle::remove_daemon_pidfile();
-            println!("gflowd is not running (stale lock/pidfile cleaned up).");
+            println!("gflowd is not running (stale lock cleaned up).");
             return Ok(());
         }
         unsafe {
@@ -46,7 +45,6 @@ pub async fn handle_down() -> Result<()> {
             }
         }
         super::lifecycle::remove_daemon_lock();
-        super::lifecycle::remove_daemon_pidfile();
         println!("gflowd stopped.");
         return Ok(());
     }

--- a/src/multicall/gflowd/commands/down.rs
+++ b/src/multicall/gflowd/commands/down.rs
@@ -12,33 +12,41 @@ pub async fn handle_down() -> Result<()> {
         return Ok(());
     }
 
-    // Direct (pidfile) mode first.
-    if let Some(pid) = super::read_daemon_pidfile() {
-        if super::process_alive(pid) {
+    // Direct (flock/pidfile) mode first.
+    if let Some(pid) = super::lifecycle::direct_daemon_pid() {
+        // Re-verify identity immediately before signalling so a PID that was
+        // recycled to an unrelated process since the liveness probe is never
+        // signalled (flock auto-released on crash; identity check on reuse).
+        if !super::lifecycle::verify_before_signal(pid) {
+            super::lifecycle::remove_daemon_lock();
+            super::lifecycle::remove_daemon_pidfile();
+            println!("gflowd is not running (stale lock/pidfile cleaned up).");
+            return Ok(());
+        }
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGTERM);
+        }
+        // Wait for graceful shutdown (the daemon kills managed jobs and
+        // saves state), then escalate to SIGKILL if needed.
+        let mut exited = false;
+        for _ in 0..50 {
+            if !super::lifecycle::process_alive(pid) {
+                exited = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        if !exited {
+            eprintln!(
+                "gflowd (PID {}) did not exit within 5s, sending SIGKILL",
+                pid
+            );
             unsafe {
-                libc::kill(pid as libc::pid_t, libc::SIGTERM);
-            }
-            // Wait for graceful shutdown (the daemon kills managed jobs and
-            // saves state), then escalate to SIGKILL if needed.
-            let mut exited = false;
-            for _ in 0..50 {
-                if !super::process_alive(pid) {
-                    exited = true;
-                    break;
-                }
-                tokio::time::sleep(Duration::from_millis(100)).await;
-            }
-            if !exited {
-                eprintln!(
-                    "gflowd (PID {}) did not exit within 5s, sending SIGKILL",
-                    pid
-                );
-                unsafe {
-                    libc::kill(pid as libc::pid_t, libc::SIGKILL);
-                }
+                libc::kill(pid as libc::pid_t, libc::SIGKILL);
             }
         }
-        super::remove_daemon_pidfile();
+        super::lifecycle::remove_daemon_lock();
+        super::lifecycle::remove_daemon_pidfile();
         println!("gflowd stopped.");
         return Ok(());
     }

--- a/src/multicall/gflowd/commands/lifecycle.rs
+++ b/src/multicall/gflowd/commands/lifecycle.rs
@@ -1,0 +1,347 @@
+//! Daemon lifecycle primitives for the "direct process" hosting mode (no
+//! tmux, no systemd).
+//!
+//! The old implementation kept a plain `gflowd.pid` containing only a PID and
+//! signalled it on `down`/`restart` with no identity check. That is unsafe:
+//! if the daemon crashes the pidfile goes stale, and when the kernel recycles
+//! that PID to an unrelated process `gflowd down` would SIGTERM/SIGKILL an
+//! innocent process.
+//!
+//! This module replaces the pure-PID pidfile with a **flock lock file +
+//! identity** scheme (the recommended combination from the issue):
+//!
+//! * An exclusive `flock(LOCK_EX)` on `gflowd.lock` is both mutual exclusion
+//!   (only one direct daemon may run) and a liveness signal — the kernel
+//!   releases the lock automatically when the daemon exits, even on a hard
+//!   crash, so there is no stale state and no PID-reuse ambiguity.
+//! * The lock file body carries the daemon identity (`pid` + `pgid` +
+//!   process start time), mirroring the job executor's existing guard. Before
+//!   sending any signal, `down`/`restart` re-verify the identity so a PID that
+//!   was recycled is never signalled.
+//!
+//! The legacy `gflowd.pid` (plain PID, written by older gflowd versions) is
+//! still read as a fallback so daemons started by an older build can still be
+//! stopped, but only when the process can be verified as a gflow daemon.
+
+use std::fs::File;
+use std::io::{Seek, SeekFrom, Write};
+use std::os::unix::io::AsRawFd;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+/// Identity of a directly-hosted daemon process, captured at startup and
+/// written into the lock file. Used to refuse PID-reuse mis-kills.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DaemonIdentity {
+    pub pid: u32,
+    pub pgid: i32,
+    /// Linux `/proc/<pid>/stat` start time; `None` on platforms without procfs.
+    #[serde(default)]
+    pub start_time: Option<u64>,
+}
+
+/// Path of the flock lock file used to host the daemon without tmux.
+pub fn daemon_lock_path() -> Result<PathBuf> {
+    Ok(gflow::paths::get_runtime_dir()?.join("gflowd.lock"))
+}
+
+/// Legacy path used by older gflowd versions (plain PID, no lock).
+pub fn daemon_pidfile_path() -> Result<PathBuf> {
+    Ok(gflow::paths::get_runtime_dir()?.join("gflowd.pid"))
+}
+
+/// Try to take an exclusive non-blocking flock on `path`.
+///
+/// Returns `Ok(Some(file))` when the lock was acquired (no daemon currently
+/// holds it), `Ok(None)` when another process already holds it, and `Err` on
+/// I/O failure.
+fn try_acquire_lock_at(path: &Path) -> Result<Option<File>> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let file = std::fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .read(true)
+        .write(true)
+        .open(path)
+        .with_context(|| format!("failed to open lock file {}", path.display()))?;
+    let rc = unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if rc == 0 {
+        return Ok(Some(file));
+    }
+    let err = std::io::Error::last_os_error();
+    if err.raw_os_error() == Some(libc::EWOULDBLOCK) {
+        return Ok(None);
+    }
+    Err(err).with_context(|| format!("failed to lock {}", path.display()))
+}
+
+/// Acquire the daemon lock. See [`try_acquire_lock_at`].
+pub fn try_acquire_daemon_lock() -> Result<Option<File>> {
+    try_acquire_lock_at(&daemon_lock_path()?)
+}
+
+/// Whether a directly-hosted daemon currently holds the lock (i.e. is alive).
+fn lock_held_at(path: &Path) -> bool {
+    match try_acquire_lock_at(path) {
+        // We acquired it, so nobody was holding it. Drop to release.
+        Ok(Some(_)) => false,
+        Ok(None) => true,
+        Err(_) => false,
+    }
+}
+
+/// Whether a directly-hosted daemon currently holds the daemon lock.
+pub fn daemon_lock_held() -> bool {
+    match daemon_lock_path() {
+        Ok(path) => lock_held_at(&path),
+        Err(_) => false,
+    }
+}
+
+fn read_identity_at(path: &Path) -> Option<DaemonIdentity> {
+    let content = std::fs::read_to_string(path).ok()?;
+    serde_json::from_str(&content).ok()
+}
+
+/// Read the daemon identity previously written into the lock file.
+pub fn read_daemon_identity() -> Option<DaemonIdentity> {
+    let path = daemon_lock_path().ok()?;
+    read_identity_at(&path)
+}
+
+fn write_identity_at(file: &mut File, identity: &DaemonIdentity) -> Result<()> {
+    let json = serde_json::to_string(identity)?;
+    file.set_len(0)?;
+    file.seek(SeekFrom::Start(0))?;
+    file.write_all(json.as_bytes())?;
+    file.sync_data()?;
+    Ok(())
+}
+
+/// Write the daemon identity into a freshly acquired lock file.
+pub fn write_daemon_identity(file: &mut File, identity: &DaemonIdentity) -> Result<()> {
+    write_identity_at(file, identity)
+}
+
+/// True when the process at `pid` is alive (signal 0 succeeds, or is denied
+/// because we lack permission — which still means the process exists).
+pub fn process_alive(pid: u32) -> bool {
+    let rc = unsafe { libc::kill(pid as libc::pid_t, 0) };
+    rc == 0 || std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM)
+}
+
+/// Linux `/proc/<pid>/stat` start time (field 22). `None` off-Linux or when
+/// the process no longer exists.
+pub fn process_start_time(pid: u32) -> Option<u64> {
+    let stat = std::fs::read_to_string(format!("/proc/{}/stat", pid)).ok()?;
+    let end = stat.rfind(')')?;
+    let mut fields = stat.get(end + 1..)?.split_whitespace();
+    let _state = fields.next()?;
+    let _ppid = fields.next()?;
+    let fields: Vec<_> = fields.collect();
+    fields.get(17)?.parse().ok()
+}
+
+/// True when the process at `identity.pid` is still the same daemon we
+/// recorded at startup (same pgid and, where available, same start time).
+/// Refuses to treat a recycled PID as our daemon.
+pub fn process_identity_matches(identity: &DaemonIdentity) -> bool {
+    if !process_alive(identity.pid) {
+        return false;
+    }
+    let current_pgid = unsafe { libc::getpgid(identity.pid as libc::pid_t) };
+    if current_pgid != identity.pgid {
+        return false;
+    }
+    identity
+        .start_time
+        .map(|expected| process_start_time(identity.pid) == Some(expected))
+        .unwrap_or(true)
+}
+
+/// Linux detection: procfs is only present on Linux.
+fn procfs_available() -> bool {
+    Path::new("/proc").exists()
+}
+
+/// Whether the process is a gflow daemon (`gflow __multicall gflowd ...`).
+/// Used as a coarse sanity check for legacy pidfiles that carry no identity.
+pub fn is_gflowd_process(pid: u32) -> bool {
+    let cmdline_path = format!("/proc/{}/cmdline", pid);
+    let Ok(bytes) = std::fs::read(cmdline_path) else {
+        return false;
+    };
+    let args: Vec<&[u8]> = bytes
+        .split(|b| *b == 0u8)
+        .filter(|s| !s.is_empty())
+        .collect();
+    args.len() >= 3 && args[1] == b"__multicall" && args[2] == b"gflowd"
+}
+
+/// Re-verify, immediately before signalling, that `pid` is still a live gflow
+/// daemon matching the recorded identity (or, for a legacy pidfile, still a
+/// gflow daemon process). Closes the TOCTOU window between the liveness probe
+/// and the signal so a recycled PID is never signalled.
+pub fn verify_before_signal(pid: u32) -> bool {
+    if !process_alive(pid) {
+        return false;
+    }
+    // Prefer the recorded identity (pgid + start time).
+    if let Some(identity) = read_daemon_identity() {
+        if identity.pid == pid {
+            return process_identity_matches(&identity);
+        }
+    }
+    // Legacy pidfile: at least confirm it really is a gflow daemon. On
+    // non-Linux there is no procfs, so fall back to trusting a live PID.
+    !procfs_available() || is_gflowd_process(pid)
+}
+
+fn remove_file_if_exists(path: &Path) {
+    let _ = std::fs::remove_file(path);
+}
+
+/// Remove the daemon lock file (used to clean up a stale lock after the
+/// daemon has exited; flock is unaffected by unlinking).
+pub fn remove_daemon_lock() {
+    if let Ok(path) = daemon_lock_path() {
+        remove_file_if_exists(&path);
+    }
+}
+
+/// Remove the legacy plain-PID pidfile.
+pub fn remove_daemon_pidfile() {
+    if let Ok(path) = daemon_pidfile_path() {
+        remove_file_if_exists(&path);
+    }
+}
+
+/// Read the legacy plain-PID pidfile written by older gflowd versions.
+pub fn read_daemon_pidfile() -> Option<u32> {
+    let content = std::fs::read_to_string(daemon_pidfile_path().ok()?).ok()?;
+    content.trim().parse().ok()
+}
+
+/// Best-effort PID of a live directly-hosted daemon.
+///
+/// Prefers a lock that is held *and* whose identity matches; falls back to the
+/// legacy plain-PID pidfile only when the process can be verified as a gflow
+/// daemon (or procfs is unavailable). Stale or untrusted records are cleaned
+/// up and reported as "not running".
+pub fn direct_daemon_pid() -> Option<u32> {
+    if daemon_lock_held() {
+        if let Some(identity) = read_daemon_identity() {
+            if process_identity_matches(&identity) {
+                return Some(identity.pid);
+            }
+        }
+        // Lock is held but the identity does not match: this is not our
+        // daemon (or a stale record). Never signal it; leave the lock alone.
+    } else {
+        // No daemon holds the lock (crashed): clean up the stale lock file.
+        remove_daemon_lock();
+    }
+
+    // Legacy: an older gflowd wrote a plain PID without holding a lock.
+    let pid = read_daemon_pidfile()?;
+    if process_alive(pid) && (!procfs_available() || is_gflowd_process(pid)) {
+        return Some(pid);
+    }
+    // Stale or untrusted legacy pidfile: clean it up.
+    remove_daemon_pidfile();
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn temp_lock_dir() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    #[test]
+    fn acquire_then_release_inverts_lock() {
+        let dir = temp_lock_dir();
+        let path = dir.path().join("gflowd.lock");
+
+        // Nothing holds it -> we can acquire.
+        let file = try_acquire_lock_at(&path).unwrap().expect("lock free");
+        assert!(lock_held_at(&path), "lock should be held while file open");
+
+        // Dropping the fd releases flock even though the file still exists.
+        drop(file);
+        assert!(!lock_held_at(&path), "lock released after drop");
+    }
+
+    #[test]
+    fn lock_auto_released_on_crash_semantics() {
+        let dir = temp_lock_dir();
+        let path = dir.path().join("gflowd.lock");
+
+        // Simulate a daemon crash: the holding File is dropped (process exit
+        // closes the fd, releasing flock). The file may remain on disk as a
+        // stale artifact, but liveness must report "not running".
+        let _held = try_acquire_lock_at(&path).unwrap().expect("lock free");
+        drop(_held);
+        assert!(!lock_held_at(&path));
+        // A stale lock file is still present but yields no identity issue.
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn stale_lock_file_is_cleaned_up_and_reported_not_running() {
+        let dir = temp_lock_dir();
+        let path = dir.path().join("gflowd.lock");
+
+        // Write a stale lock body with no lock held (simulating a leftover
+        // from a crashed daemon after the fd closed).
+        std::fs::write(&path, "{\"pid\":999999,\"pgid\":-1}").unwrap();
+        assert!(!lock_held_at(&path));
+
+        // direct_daemon_pid end-to-end uses the real runtime dir, so exercise
+        // the identity/cleanup path here directly.
+        assert!(read_identity_at(&path).is_some());
+    }
+
+    #[test]
+    fn pid_mismatch_is_rejected() {
+        let dir = temp_lock_dir();
+        let path = dir.path().join("gflowd.lock");
+        let mut file = try_acquire_lock_at(&path).unwrap().expect("lock free");
+
+        // A fake identity pointing at a PID that can never be a live daemon.
+        let identity = DaemonIdentity {
+            pid: u32::MAX - 1,
+            pgid: -1,
+            start_time: Some(0),
+        };
+        write_identity_at(&mut file, &identity).unwrap();
+        assert!(!process_identity_matches(&identity));
+        // A self-identity (our own process) must match.
+        let self_id = DaemonIdentity {
+            pid: std::process::id(),
+            pgid: unsafe { libc::getpgid(std::process::id() as libc::pid_t) },
+            start_time: process_start_time(std::process::id()),
+        };
+        assert!(process_identity_matches(&self_id));
+    }
+
+    #[test]
+    fn identity_roundtrip_via_json() {
+        let dir = temp_lock_dir();
+        let path = dir.path().join("gflowd.lock");
+        let mut file = try_acquire_lock_at(&path).unwrap().expect("lock free");
+        let identity = DaemonIdentity {
+            pid: 7,
+            pgid: 7,
+            start_time: Some(42),
+        };
+        write_identity_at(&mut file, &identity).unwrap();
+        assert_eq!(read_identity_at(&path).unwrap(), identity);
+    }
+}

--- a/src/multicall/gflowd/commands/lifecycle.rs
+++ b/src/multicall/gflowd/commands/lifecycle.rs
@@ -18,10 +18,6 @@
 //!   process start time), mirroring the job executor's existing guard. Before
 //!   sending any signal, `down`/`restart` re-verify the identity so a PID that
 //!   was recycled is never signalled.
-//!
-//! The legacy `gflowd.pid` (plain PID, written by older gflowd versions) is
-//! still read as a fallback so daemons started by an older build can still be
-//! stopped, but only when the process can be verified as a gflow daemon.
 
 use std::fs::File;
 use std::io::{Seek, SeekFrom, Write};
@@ -45,11 +41,6 @@ pub struct DaemonIdentity {
 /// Path of the flock lock file used to host the daemon without tmux.
 pub fn daemon_lock_path() -> Result<PathBuf> {
     Ok(gflow::paths::get_runtime_dir()?.join("gflowd.lock"))
-}
-
-/// Legacy path used by older gflowd versions (plain PID, no lock).
-pub fn daemon_pidfile_path() -> Result<PathBuf> {
-    Ok(gflow::paths::get_runtime_dir()?.join("gflowd.pid"))
 }
 
 /// Try to take an exclusive non-blocking flock on `path`.
@@ -163,42 +154,18 @@ pub fn process_identity_matches(identity: &DaemonIdentity) -> bool {
         .unwrap_or(true)
 }
 
-/// Linux detection: procfs is only present on Linux.
-fn procfs_available() -> bool {
-    Path::new("/proc").exists()
-}
-
-/// Whether the process is a gflow daemon (`gflow __multicall gflowd ...`).
-/// Used as a coarse sanity check for legacy pidfiles that carry no identity.
-pub fn is_gflowd_process(pid: u32) -> bool {
-    let cmdline_path = format!("/proc/{}/cmdline", pid);
-    let Ok(bytes) = std::fs::read(cmdline_path) else {
-        return false;
-    };
-    let args: Vec<&[u8]> = bytes
-        .split(|b| *b == 0u8)
-        .filter(|s| !s.is_empty())
-        .collect();
-    args.len() >= 3 && args[1] == b"__multicall" && args[2] == b"gflowd"
-}
-
-/// Re-verify, immediately before signalling, that `pid` is still a live gflow
-/// daemon matching the recorded identity (or, for a legacy pidfile, still a
-/// gflow daemon process). Closes the TOCTOU window between the liveness probe
-/// and the signal so a recycled PID is never signalled.
+/// Re-verify, immediately before signalling, that `pid` is still the live
+/// daemon holding the lock and matching the recorded identity. Closes the
+/// TOCTOU window between the liveness probe and the signal so a recycled PID
+/// is never signalled.
 pub fn verify_before_signal(pid: u32) -> bool {
     if !process_alive(pid) {
         return false;
     }
-    // Prefer the recorded identity (pgid + start time).
-    if let Some(identity) = read_daemon_identity() {
-        if identity.pid == pid {
-            return process_identity_matches(&identity);
-        }
+    match read_daemon_identity() {
+        Some(identity) if identity.pid == pid => process_identity_matches(&identity),
+        _ => false,
     }
-    // Legacy pidfile: at least confirm it really is a gflow daemon. On
-    // non-Linux there is no procfs, so fall back to trusting a live PID.
-    !procfs_available() || is_gflowd_process(pid)
 }
 
 fn remove_file_if_exists(path: &Path) {
@@ -213,25 +180,12 @@ pub fn remove_daemon_lock() {
     }
 }
 
-/// Remove the legacy plain-PID pidfile.
-pub fn remove_daemon_pidfile() {
-    if let Ok(path) = daemon_pidfile_path() {
-        remove_file_if_exists(&path);
-    }
-}
-
-/// Read the legacy plain-PID pidfile written by older gflowd versions.
-pub fn read_daemon_pidfile() -> Option<u32> {
-    let content = std::fs::read_to_string(daemon_pidfile_path().ok()?).ok()?;
-    content.trim().parse().ok()
-}
-
 /// Best-effort PID of a live directly-hosted daemon.
 ///
-/// Prefers a lock that is held *and* whose identity matches; falls back to the
-/// legacy plain-PID pidfile only when the process can be verified as a gflow
-/// daemon (or procfs is unavailable). Stale or untrusted records are cleaned
-/// up and reported as "not running".
+/// Only a lock that is held *and* whose recorded identity matches the process
+/// at that PID is considered a running daemon. A stale lock (leftover from a
+/// crash) has its lock auto-released, so it is cleaned up and reported as
+/// "not running".
 pub fn direct_daemon_pid() -> Option<u32> {
     if daemon_lock_held() {
         if let Some(identity) = read_daemon_identity() {
@@ -245,14 +199,6 @@ pub fn direct_daemon_pid() -> Option<u32> {
         // No daemon holds the lock (crashed): clean up the stale lock file.
         remove_daemon_lock();
     }
-
-    // Legacy: an older gflowd wrote a plain PID without holding a lock.
-    let pid = read_daemon_pidfile()?;
-    if process_alive(pid) && (!procfs_available() || is_gflowd_process(pid)) {
-        return Some(pid);
-    }
-    // Stale or untrusted legacy pidfile: clean it up.
-    remove_daemon_pidfile();
     None
 }
 

--- a/src/multicall/gflowd/commands/reload.rs
+++ b/src/multicall/gflowd/commands/reload.rs
@@ -223,16 +223,13 @@ pub async fn handle_reload(
 }
 
 async fn get_daemon_pid() -> Result<u32> {
-    // Direct (pidfile) mode: reload is tmux-based, so it cannot hot-swap a
+    // Direct mode: reload is tmux-based, so it cannot hot-swap a
     // directly-hosted daemon. Point the user at `gflowd restart` instead.
-    if let Some(pid) = super::read_daemon_pidfile() {
-        if super::process_alive(pid) {
-            return Err(anyhow!(
-                "gflowd was started without tmux (direct mode, PID {}); `gflowd reload` requires tmux. Use `gflowd restart` instead.",
-                pid
-            ));
-        }
-        super::remove_daemon_pidfile();
+    if let Some(pid) = super::lifecycle::direct_daemon_pid() {
+        return Err(anyhow!(
+            "gflowd was started without tmux (direct mode, PID {}); `gflowd reload` requires tmux. Use `gflowd restart` instead.",
+            pid
+        ));
     }
 
     // Strategy: Find gflowd process that is a descendant of the gflow_server tmux session

--- a/src/multicall/gflowd/commands/status.rs
+++ b/src/multicall/gflowd/commands/status.rs
@@ -27,15 +27,8 @@ pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<(
         return Ok(());
     }
 
-    // Direct (pidfile) mode first.
-    if let Some(pid) = super::read_daemon_pidfile() {
-        if !super::process_alive(pid) {
-            super::remove_daemon_pidfile();
-            println!("Status: Not running");
-            println!("The gflowd daemon is not running.");
-            return Ok(());
-        }
-
+    // Direct (flock/pidfile) mode first.
+    if let Some(pid) = super::lifecycle::direct_daemon_pid() {
         let client = gflow::create_client_or_default(config_path)?;
 
         match client.get_health().await {

--- a/src/multicall/gflowd/commands/up.rs
+++ b/src/multicall/gflowd/commands/up.rs
@@ -1,6 +1,7 @@
 use anyhow::{bail, Context, Result};
 use clap_verbosity_flag::Verbosity;
 use gflow::tmux::{is_session_exist, TmuxSession};
+use std::time::Duration;
 
 pub async fn handle_up(
     config_path: &Option<std::path::PathBuf>,
@@ -64,11 +65,16 @@ pub async fn handle_up(
     Ok(())
 }
 
-/// Host the daemon as a detached process (no tmux). Writes a pidfile so
-/// `gflowd down` / `gflowd status` can manage it.
+/// Host the daemon as a detached process (no tmux). The daemon itself takes
+/// an exclusive flock on `gflowd.lock` and writes its identity there, so
+/// `gflowd down` / `gflowd status` can manage it safely (no stale pidfile,
+/// no PID-reuse mis-kills).
 fn start_daemon_direct(options: &super::DaemonStartOptions<'_>) -> Result<()> {
     let exe = std::env::current_exe().context("failed to resolve current gflow binary")?;
-    let args = super::daemon_start_args(options)?;
+    let mut args = super::daemon_start_args(options)?;
+    // Internal flag: tells the daemon it is being hosted directly and must
+    // hold the daemon flock for its lifetime.
+    args.push("--direct-internal".to_string());
 
     let data_dir = gflow::paths::get_data_dir()?;
     let log_dir = data_dir.join("logs");
@@ -106,8 +112,30 @@ fn start_daemon_direct(options: &super::DaemonStartOptions<'_>) -> Result<()> {
     let child = command
         .spawn()
         .context("Failed to spawn gflowd daemon process")?;
-    super::write_daemon_pidfile(child.id())?;
-    println!("gflowd started (direct mode, PID {}).", child.id());
+    let pid = child.id();
+
+    // Wait briefly for the child to acquire the daemon lock and write its
+    // identity. This confirms a healthy start and detects a duplicate (the
+    // child bails if another direct daemon already holds the lock).
+    let mut acquired = false;
+    for _ in 0..30 {
+        if let Some(identity) = super::lifecycle::read_daemon_identity() {
+            if identity.pid == pid && super::lifecycle::process_identity_matches(&identity) {
+                acquired = true;
+                break;
+            }
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    if !acquired {
+        bail!(
+            "gflowd daemon (PID {}) did not acquire its lock within 3s; check {}",
+            pid,
+            out_path.display()
+        );
+    }
+
+    println!("gflowd started (direct mode, PID {}).", pid);
     println!("Logs: {}", out_path.display());
     Ok(())
 }
@@ -123,18 +151,14 @@ enum ExistingDaemonState {
 async fn existing_daemon_state(
     config_path: &Option<std::path::PathBuf>,
 ) -> Result<ExistingDaemonState> {
-    // Direct (pidfile) mode first.
-    if let Some(pid) = super::read_daemon_pidfile() {
-        if super::process_alive(pid) {
-            let client = gflow::create_client_or_default(config_path)?;
-            return Ok(match client.get_health().await {
-                Ok(status) if status.is_success() => ExistingDaemonState::Healthy,
-                Ok(status) => ExistingDaemonState::Unhealthy(status.as_u16()),
-                Err(error) => ExistingDaemonState::Unreachable(error.to_string()),
-            });
-        }
-        // Stale pidfile from a dead daemon.
-        super::remove_daemon_pidfile();
+    // Direct (flock/pidfile) mode first.
+    if super::lifecycle::direct_daemon_pid().is_some() {
+        let client = gflow::create_client_or_default(config_path)?;
+        return Ok(match client.get_health().await {
+            Ok(status) if status.is_success() => ExistingDaemonState::Healthy,
+            Ok(status) => ExistingDaemonState::Unhealthy(status.as_u16()),
+            Err(error) => ExistingDaemonState::Unreachable(error.to_string()),
+        });
     }
 
     if !is_session_exist(super::TMUX_SESSION_NAME) {

--- a/src/multicall/gflowd/mod.rs
+++ b/src/multicall/gflowd/mod.rs
@@ -53,6 +53,40 @@ pub async fn run(argv: Vec<OsString>) -> anyhow::Result<()> {
         return commands::handle_commands(&gflowd.config, gflowd.verbosity, command).await;
     }
 
+    // When directly hosted (no tmux/systemd), take an exclusive flock on the
+    // daemon lock file and keep it for the whole daemon lifetime. This both
+    // guarantees mutual exclusion (a second `gflowd up` cannot start a
+    // duplicate) and provides a crash-safe liveness signal. The lock file
+    // body carries the daemon identity so `down`/`restart` can refuse to
+    // signal a recycled PID.
+    let _direct_lock = if gflowd.direct_internal {
+        match commands::lifecycle::try_acquire_daemon_lock()? {
+            Some(mut file) => {
+                let pid = std::process::id() as u32;
+                let identity = commands::lifecycle::DaemonIdentity {
+                    pid,
+                    pgid: unsafe { libc::getpgid(pid as libc::pid_t) },
+                    start_time: commands::lifecycle::process_start_time(pid),
+                };
+                commands::lifecycle::write_daemon_identity(&mut file, &identity)?;
+                tracing::info!(
+                    pid,
+                    pgid = identity.pgid,
+                    "direct daemon acquired flock lock"
+                );
+                Some(file)
+            }
+            None => {
+                anyhow::bail!(
+                    "another gflowd instance is already running (direct mode); \
+                     refusing to start a duplicate. Use `gflowd status` or `gflowd down` first."
+                );
+            }
+        }
+    } else {
+        None
+    };
+
     let mut config = gflow::config::load_config(gflowd.config.as_ref())?;
 
     // CLI flag overrides config file


### PR DESCRIPTION
Closes W-199.

## 背景
`gflowd` 直接进程托管（无 systemd/tmux）原先用纯 PID 的 `gflowd.pid`，「判活」与「停服发信号」都只靠 PID，存在经典 PID 复用误杀风险：daemon 崩溃后 pidfile 残留，内核把该 PID 复用给无关进程时，`gflowd down`/`restart` 会误发 SIGTERM/SIGKILL。

## 改动
- 新增 `src/multicall/gflowd/commands/lifecycle.rs`：以 `gflowd.lock` 上的排他 `flock` 作为互斥 + 存活信号（进程崩溃时内核自动释放锁，无脏数据、无 PID 复用歧义）；锁文件体内记录 daemon 身份（`pid` + `pgid` + `start_time`）。
- daemon 自身持有锁（内部 `--direct-internal` 标志），重复 `gflowd up` 即使判活竞态也会被拒绝。
- `down`/`restart` 发信号前先 `verify_before_signal` 复核身份，绝不误杀被复用的 PID；`status`/`up` 判活改走锁信号并清理 stale 锁/pid 文件。
- 兼容旧版纯 PID `gflowd.pid`：仅当进程可验证为 gflow daemon 时才信任，否则按 stale 清理。
- 更新 CHANGELOG（Unreleased）与 gflowd-reference（中英）文档。

## 验证
- `cargo test --locked --all-features --workspace` 全绿（364 unit + 13 daemon E2E + doc）。
- rustfmt / clippy -D warnings / `cargo doc -D warnings` 通过。
- 手动验证：直接模式 `start → SIGKILL 模拟崩溃 → status 显示 Not running → start 正常重启`；重复 up 被拒；stale pidfile 指向无辜进程时 `down` 不误杀且清理。