### PR TITLE
fix(ci): use macos-15 instead of retired macos-13 runner

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -111,7 +111,7 @@ jobs:
                 platform:
                     - runner: macos-14
                       target: aarch64-apple-darwin
-                    - runner: macos-13
+                    - runner: macos-15
                       target: x86_64-apple-darwin
         steps:
             - uses: actions/checkout@v7

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -57,7 +57,7 @@ jobs:
                 platform:
                     - runner: macos-14
                       target: aarch64-apple-darwin
-                    - runner: macos-13
+                    - runner: macos-15
                       target: x86_64-apple-darwin
         steps:
             - uses: actions/checkout@v7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `Timeout` to grouped job state displays
 
 ### Fixed
+- **CI: stop using the retired `macos-13` runner label** in the nightly and PyPI release pipelines — the `x86_64-apple-darwin` wheel now builds on the still-supported `macos-15` (Intel) runner instead, so the nightly build no longer blocks waiting on a discontinued macOS 13 image
 - Pattern matching in `gcancel` to handle new `Timeout` state
 - Job struct serialization to properly persist time limit information
 - Tmux session cleanup to ensure pipe-pane is disabled before session termination


### PR DESCRIPTION
## Summary

The GitHub-hosted `macos-13` runner image has been retired, so the `x86_64-apple-darwin` wheel job in the nightly pipeline queues indefinitely and blocks the `publish` step (which `needs: [check, linux, macos, sdist]`).

### Change
- `nightly.yml` and `pypi.yml`: move the `x86_64-apple-darwin` macOS build from the retired `macos-13` label to the supported Intel `macos-15` runner. The `aarch64-apple-darwin` build stays on `macos-14`.
- `CHANGELOG.md`: note under Unreleased → Fixed.

Ref W-225