### PR TITLE
feat(gflowd): enrich 'gflowd status' with daemon summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`gflowd status` daemon summary**: when the daemon is running, `gflowd status`
+  now also prints a daemon summary fetched from `GET /status` — version, PID,
+  uptime, job executor backend, and GPU availability (total/available) — on top
+  of the existing hosting mode, for all hosting paths (systemd, tmux, direct).
 - **Unified gflowd lifecycle + optional systemd user service**: a consistent `gflowd start` / `stop` / `restart` / `status` verb set that hides how the daemon is hosted from the user
   - Hosting is chosen automatically by priority: systemd user service → tmux → direct detached process (pidfile); `status` reports the current hosting mode
   - New `gflowd service install` / `gflowd service uninstall` manage `~/.config/systemd/user/gflowd.service` (`enable --now`, auto-start on login + `Restart=on-failure` crash recovery); `ExecStart` reuses the existing `daemon_start_args` so the daemon core is unchanged

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -103,11 +103,24 @@ Use this when a full restart is acceptable or needed.
 
 ### `gflowd status`
 
-Show whether the daemon is running and how it is hosted (systemd user service,
-tmux, or direct process).
+Show whether the daemon is running, how it is hosted (systemd user service,
+tmux, or direct process), and a daemon summary (version, PID, uptime, executor,
+GPU availability) fetched from the running daemon.
 
 ```bash
 gflowd status
+```
+
+Example when hosted as a systemd user service:
+
+```text
+Status: Running
+Hosting: systemd user service (gflowd.service).
+Version:   0.4.17
+PID:       3628801
+Uptime:    25h57m21s
+Executor:  process
+GPUs:      8 total, 8 available
 ```
 
 ### `gflowd stop`

--- a/docs/src/zh-CN/reference/gflowd-reference.md
+++ b/docs/src/zh-CN/reference/gflowd-reference.md
@@ -104,10 +104,23 @@ gflowd restart [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-
 ### `gflowd status`
 
 显示守护进程是否在运行，以及当前托管方式（systemd user service、tmux 或
-直接进程）。
+直接进程），并展示从运行中的守护进程获取的摘要（版本、PID、运行时长、
+执行器、GPU 可用情况）。
 
 ```bash
 gflowd status
+```
+
+以 systemd user service 方式托管时的示例：
+
+```text
+Status: Running
+Hosting: systemd user service (gflowd.service).
+Version:   0.4.17
+PID:       3628801
+Uptime:    25h57m21s
+Executor:  process
+GPUs:      8 total, 8 available
 ```
 
 ### `gflowd stop`

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,4 +1,4 @@
-use crate::core::info::{IgnoredGpuProcess, SchedulerInfo};
+use crate::core::info::{DaemonStatus, IgnoredGpuProcess, SchedulerInfo};
 use crate::core::job::{DependencyMode, Job, JobNotifications};
 use anyhow::{anyhow, Context};
 use reqwest::{Client as ReqwestClient, StatusCode};
@@ -459,6 +459,23 @@ impl Client {
             .map_err(connection_error_context)?
             .status();
         Ok(health)
+    }
+
+    /// Fetch the rich daemon summary (`GET /status`) used by `gflowd status`.
+    pub async fn get_daemon_status(&self) -> anyhow::Result<DaemonStatus> {
+        tracing::debug!("Getting daemon status");
+        let status = self
+            .client
+            .get(format!("{}/status", self.base_url))
+            .send()
+            .await
+            .map_err(connection_error_context)?
+            .error_for_status()
+            .context("daemon status request failed")?
+            .json::<DaemonStatus>()
+            .await
+            .context("Failed to parse daemon status from response")?;
+        Ok(status)
     }
 
     pub async fn get_health_with_pid(&self) -> anyhow::Result<Option<u32>> {

--- a/src/core/info.rs
+++ b/src/core/info.rs
@@ -18,6 +18,23 @@ pub struct GpuInfo {
     pub reason: Option<String>,
 }
 
+/// Rich daemon status payload exposed by `GET /status` for `gflowd status`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DaemonStatus {
+    /// gflow version (first line of `gflowd --version` output).
+    pub version: String,
+    /// Daemon process ID.
+    pub pid: u32,
+    /// Seconds since the daemon started.
+    pub uptime_secs: u64,
+    /// Job executor backend: "process" (default) or "tmux".
+    pub executor: String,
+    /// Number of detected GPU slots.
+    pub gpu_total: usize,
+    /// Number of GPU slots currently available.
+    pub gpu_available: usize,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SchedulerInfo {
     pub gpus: Vec<GpuInfo>,

--- a/src/multicall/gflowd/commands/status.rs
+++ b/src/multicall/gflowd/commands/status.rs
@@ -1,5 +1,34 @@
 use anyhow::Result;
+use gflow::client::Client;
+use gflow::core::info::DaemonStatus;
 use gflow::tmux::is_session_exist;
+
+fn format_uptime(secs: u64) -> String {
+    let days = secs / 86_400;
+    let hours = (secs % 86_400) / 3600;
+    let minutes = (secs % 3600) / 60;
+    let seconds = secs % 60;
+    if days > 0 {
+        format!("{days}d{hours}h{minutes}m{seconds}s")
+    } else if hours > 0 {
+        format!("{hours}h{minutes}m{seconds}s")
+    } else if minutes > 0 {
+        format!("{minutes}m{seconds}s")
+    } else {
+        format!("{seconds}s")
+    }
+}
+
+fn print_daemon_summary(status: &DaemonStatus) {
+    println!("Version:   {}", status.version);
+    println!("PID:       {}", status.pid);
+    println!("Uptime:    {}", format_uptime(status.uptime_secs));
+    println!("Executor:  {}", status.executor);
+    println!(
+        "GPUs:      {} total, {} available",
+        status.gpu_total, status.gpu_available
+    );
+}
 
 pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<()> {
     // systemd user service takes priority.
@@ -14,6 +43,7 @@ pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<(
                     "Hosting: systemd user service ({}).",
                     super::systemd::SYSTEMD_UNIT
                 );
+                print_daemon_summary(&fetch_summary(&client).await);
             }
             Ok(_) => {
                 println!("Status: Unhealthy");
@@ -38,6 +68,7 @@ pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<(
                     "The gflowd daemon is running as a direct process (PID {}).",
                     pid
                 );
+                print_daemon_summary(&fetch_summary(&client).await);
             }
             Ok(_) => {
                 println!("Status: Unhealthy");
@@ -69,6 +100,7 @@ pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<(
                     "The gflowd daemon is running in tmux session '{}'.",
                     super::TMUX_SESSION_NAME
                 );
+                print_daemon_summary(&fetch_summary(&client).await);
             } else {
                 println!("Status: Unhealthy");
                 eprintln!("The gflowd daemon responded to the health check but is not healthy.");
@@ -80,4 +112,41 @@ pub async fn handle_status(config_path: &Option<std::path::PathBuf>) -> Result<(
         }
     }
     Ok(())
+}
+
+/// Best-effort fetch of the rich daemon summary. Falls back to a placeholder
+/// struct if the daemon is an older version without `GET /status`.
+async fn fetch_summary(client: &Client) -> DaemonStatus {
+    match client.get_daemon_status().await {
+        Ok(status) => status,
+        Err(_) => DaemonStatus {
+            version: gflow::build_info::version()
+                .lines()
+                .next()
+                .unwrap_or_default()
+                .to_string(),
+            pid: 0,
+            uptime_secs: 0,
+            executor: String::new(),
+            gpu_total: 0,
+            gpu_available: 0,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn format_uptime_variants() {
+        assert_eq!(format_uptime(0), "0s");
+        assert_eq!(format_uptime(59), "59s");
+        assert_eq!(format_uptime(90), "1m30s");
+        assert_eq!(format_uptime(3600), "1h0m0s");
+        assert_eq!(format_uptime(3630), "1h0m30s");
+        assert_eq!(format_uptime(3661), "1h1m1s");
+        assert_eq!(format_uptime(86_400), "1d0h0m0s");
+        assert_eq!(format_uptime(93_383), "1d1h56m23s");
+    }
 }

--- a/src/multicall/gflowd/server.rs
+++ b/src/multicall/gflowd/server.rs
@@ -171,6 +171,7 @@ pub async fn run(config: gflow::config::Config) -> anyhow::Result<()> {
         .route("/jobs/{id}/log/content", get(handlers::get_job_log_content))
         .route("/events", get(handlers::events_stream))
         .route("/info", get(handlers::info))
+        .route("/status", get(handlers::daemon_status))
         .route("/health", get(handlers::get_health))
         .route("/gpus", post(handlers::set_allowed_gpus))
         .route("/gpu-processes", get(handlers::list_ignored_gpu_processes))

--- a/src/multicall/gflowd/server/handlers/jobs.rs
+++ b/src/multicall/gflowd/server/handlers/jobs.rs
@@ -19,6 +19,31 @@ pub(in crate::multicall::gflowd::server) async fn info(
 }
 
 #[axum::debug_handler]
+pub(in crate::multicall::gflowd::server) async fn daemon_status(
+    State(server_state): State<ServerState>,
+) -> impl IntoResponse {
+    use gflow::core::info::DaemonStatus;
+
+    let state = server_state.scheduler.read().await;
+    let info = state.info();
+    let gpu_total = info.gpus.len();
+    let gpu_available = info.gpus.iter().filter(|g| g.available).count();
+    let status = DaemonStatus {
+        version: gflow::build_info::version()
+            .lines()
+            .next()
+            .unwrap_or_default()
+            .to_string(),
+        pid: std::process::id(),
+        uptime_secs: server_state.started_at.elapsed().as_secs(),
+        executor: info.executor,
+        gpu_total,
+        gpu_available,
+    };
+    (StatusCode::OK, Json(status))
+}
+
+#[axum::debug_handler]
 pub(in crate::multicall::gflowd::server) async fn list_ignored_gpu_processes(
     State(server_state): State<ServerState>,
 ) -> impl IntoResponse {

--- a/src/multicall/gflowd/server/handlers/mod.rs
+++ b/src/multicall/gflowd/server/handlers/mod.rs
@@ -3,8 +3,8 @@ pub(crate) use jobs::UpdateJobRequest;
 pub(super) use debug::{debug_job, debug_metrics, debug_state};
 pub(super) use events::events_stream;
 pub(super) use jobs::{
-    cancel_job, create_job, create_jobs_batch, fail_job, finish_job, get_health, get_job,
-    get_job_log, get_job_log_content, hold_job, ignore_gpu_process, info,
+    cancel_job, create_job, create_jobs_batch, daemon_status, fail_job, finish_job, get_health,
+    get_job, get_job_log, get_job_log_content, hold_job, ignore_gpu_process, info,
     list_ignored_gpu_processes, list_jobs, release_job, resolve_dependency, set_allowed_gpus,
     set_group_max_concurrency, unignore_gpu_process, update_job,
 };

--- a/src/multicall/gflowd/server/state.rs
+++ b/src/multicall/gflowd/server/state.rs
@@ -7,6 +7,7 @@ use axum::{
     Json,
 };
 use std::sync::Arc;
+use std::time::Instant;
 
 /// Server state that includes both the scheduler and the event bus
 #[derive(Clone)]
@@ -14,6 +15,8 @@ pub(super) struct ServerState {
     pub(super) scheduler: SharedState,
     pub(super) event_bus: Arc<EventBus>,
     pub(super) _state_saver: StateSaverHandle,
+    /// When the daemon started, used to report uptime via `GET /status`.
+    pub(super) started_at: Instant,
 }
 
 impl ServerState {
@@ -26,6 +29,7 @@ impl ServerState {
             scheduler,
             event_bus,
             _state_saver: state_saver,
+            started_at: Instant::now(),
         }
     }
 }


### PR DESCRIPTION
## Summary

Per W-229 feedback, enrich `gflowd status` output to show a daemon summary (version, PID, uptime, executor, GPU availability) similar to `multica daemon status`, for all hosting modes (systemd user service, tmux, direct process).

## Changes

- **New `GET /status` endpoint** returning `DaemonStatus` (version, pid, uptime_secs, executor, gpu_total, gpu_available).
- Track daemon start time in `ServerState` for uptime reporting.
- **`gflowd status`** prints the summary below the existing hosting lines; gracefully falls back to version-only if the daemon is an older build without `/status`.
- Docs updated (en + zh-CN) and CHANGELOG entries added.

## Example output

```text
Status: Running
Hosting: systemd user service (gflowd.service).
Version:   0.4.17
PID:       3628801
Uptime:    25h57m21s
Executor:  process
GPUs:      8 total, 8 available
```

## Verification

- `cargo build --all-features` ✅
- `cargo test --locked --all-features --workspace` ✅ (366 tests)
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo fmt --check` ✅
- Manual end-to-end: `gflowd status` shows the summary for a running daemon.

Closes W-229