### PR TITLE
fix(gflowd): show 'up'/'down' aliases in help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Added `Timeout` to grouped job state displays
 
 ### Fixed
+- **`gflowd --help` now shows the `up` / `down` aliases**: `gflowd up` and `gflowd down` already worked as aliases of `start` / `stop`, but were hidden from the help output. They are now advertised inline (`start [aliases: up]`, `stop [aliases: down]`) so the help matches the commands that are actually accepted.
 - **CI: stop using the retired `macos-13` runner label** in the nightly and PyPI release pipelines — the `x86_64-apple-darwin` wheel now builds on the still-supported `macos-15` (Intel) runner instead, so the nightly build no longer blocks waiting on a discontinued macOS 13 image
 - Pattern matching in `gcancel` to handle new `Timeout` state
 - Job struct serialization to properly persist time limit information

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -79,7 +79,7 @@ service if installed, otherwise tmux, otherwise a direct detached process.
 gflowd start [--gpus <indices>] [--gpu-allocation-strategy <strategy>] [--gpu-poll-interval-secs <seconds>]
 ```
 
-`up` is retained as an alias of `start`.
+`up` is an alias of `start` and is shown as such in `gflowd --help` (`start [aliases: up]`).
 
 ### `gflowd reload`
 
@@ -131,7 +131,7 @@ Stop the daemon.
 gflowd stop
 ```
 
-`down` is retained as an alias of `stop`.
+`down` is an alias of `stop` and is shown as such in `gflowd --help` (`stop [aliases: down]`).
 
 ### `gflowd service`
 

--- a/src/multicall/gflowd/cli.rs
+++ b/src/multicall/gflowd/cli.rs
@@ -101,10 +101,10 @@ pub enum Commands {
         daemon_overrides: DaemonOverrideArgs,
     },
     /// Start the daemon (systemd user service if available, else tmux, else direct process)
-    #[command(alias = "up")]
+    #[command(visible_alias = "up")]
     Start(DaemonOverrideArgs),
     /// Stop the daemon
-    #[command(alias = "down")]
+    #[command(visible_alias = "down")]
     Stop,
     /// Restart the daemon
     Restart(DaemonOverrideArgs),


### PR DESCRIPTION
Closes W-231

## Problem
`gflowd up` / `gflowd down` worked (they were clap `alias`es of `start` / `stop`), but hidden aliases are not advertised, so `gflowd --help` did not show them — the help output was inconsistent with what users can actually run.

## Fix
Switched the two subcommand attributes from `alias` to `visible_alias`. Now `gflowd --help` advertises:

```
Commands:
  init        ...
  start       Start the daemon (...) [aliases: up]
  stop        Stop the daemon [aliases: down]
  restart     ...
  ...
```

`gflowd up` / `gflowd down` still work exactly as before (they route to `start` / `stop`). This keeps the design intent that `up`/`down` are aliases of `start`/`stop` (per CHANGELOG), rather than presenting them as independent commands.

## Validation
- `cargo build --bin gflowd` succeeds
- `gflowd --help` shows `[aliases: up]` / `[aliases: down]`; `gflowd up` / `gflowd down` still resolve
- `cargo test --locked --all-features --workspace gflowd`: 80 passed
- `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features` clean
- CHANGELOG.md + docs/src/reference/gflowd-reference.md updated