### PR TITLE
build: route rustc through sccache at repo level

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,20 @@
+# Repository-level Cargo configuration for gflow.
+#
+# sccache: forward all rustc invocations through sccache (a local compile cache)
+# so that repeated / cross-task builds (multica agent runs, CI, clean rebuilds)
+# reuse cached artifacts. Cache data lives in the shared per-user cache dir
+# (~/.cache/sccache), so different tasks on the same machine hit each other.
+#
+# Trade-off: `incremental = false` in the dev profile is what makes sccache
+# actually cache lib-crate compilations (sccache does not cache incremental
+# output, and errors out if CARGO_INCREMENTAL=1 is set). The cost is that
+# day-to-day iterative `cargo build` recompiles the changed crate fully instead
+# of incrementally. If you prefer incremental dev builds, delete the
+# `[profile.dev]` block below (or call `CARGO_INCREMENTAL=0` / release builds
+# when you want cacheable full rebuilds).
+
+[build]
+rustc-wrapper = "sccache"
+
+[profile.dev]
+incremental = false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dependency Shorthand**: `gbatch --depends-on` now accepts `@` (last) and `@~N` (Nth from the end) to reference recent submissions without copying job IDs
 
 ### Changed
+- **Repo-level cargo build config routes rustc through sccache**: a new
+  `.cargo/config.toml` sets `[build] rustc-wrapper = "sccache"` for a shared
+  local compile cache across multica/CI/clean rebuilds, and disables incremental
+  compilation in the dev profile (`[profile.dev] incremental = false`) so
+  sccache can actually cache lib-crate compilations (sccache does not cache
+  incremental output). Iterative local dev builds compile the changed crate
+  fully instead of incrementally; set `CARGO_INCREMENTAL=0` or use a release
+  profile for cacheable full rebuilds, or drop the `[profile.dev]` block to
+  restore incremental dev builds.
+
 - **Direct-process daemon hosting hardened against PID reuse**: `gflowd`'s
   no-tmux hosting now uses an exclusive `flock` on a `gflowd.lock` file as the
   mutual-exclusion and liveness signal, instead of a bare `gflowd.pid`


### PR DESCRIPTION
## What

Add repo-level `.cargo/config.toml` to gflow so all cargo builds go through `sccache` (a shared local compile cache), and disable incremental compilation in the dev profile so sccache can actually cache lib-crate compilations.

Implements the repo-level setup requested in W-230 (why multica/CI builds don't benefit from sccache: incremental output is not cached by sccache, and bin crates are not cached — only lib-crate dependencies are).

## Changes

- `.cargo/config.toml`: `[build] rustc-wrapper = "sccache"` + `[profile.dev] incremental = false`
- `CHANGELOG.md`: note under Unreleased → Changed

## Trade-off

`incremental = false` in the dev profile makes sccache effective (needed for cache hits) but means iterative local `cargo build` recompiles the changed crate fully. Use `CARGO_INCREMENTAL=0` / release profile for cacheable full rebuilds, or drop the `[profile.dev]` block to restore incremental dev builds.

Refs W-230