### PR TITLE
revert(executor): default job executor back to tmux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Hosting is chosen automatically by priority: systemd user service → tmux → direct detached process (pidfile); `status` reports the current hosting mode
   - New `gflowd service install` / `gflowd service uninstall` manage `~/.config/systemd/user/gflowd.service` (`enable --now`, auto-start on login + `Restart=on-failure` crash recovery); `ExecStart` reuses the existing `daemon_start_args` so the daemon core is unchanged
   - `up` / `down` are retained as aliases of `start` / `stop` for backwards compatibility
-- **Process executor (default)**: jobs now run as detached child process groups (`setsid`) with stdio redirected to `logs/<job_id>.log` — no tmux required for job execution
-  - New `[executor] type = "process" | "tmux"` config; `process` is the default, the legacy tmux executor remains fully available (`gjob attach` / `gjob close-sessions` keep working in tmux mode)
+- **Process executor (experimental, opt-in)**: jobs can run as detached child process groups (`setsid`) with stdio redirected to `logs/<job_id>.log` — no tmux required for job execution
+  - New `[executor] type = "process" | "tmux"` config; `tmux` is the default, the process executor is opt-in and not yet considered stable (`gjob attach` / `gjob close-sessions` keep working in tmux mode)
   - Cancellation SIGTERMs the whole process group and escalates to SIGKILL after a grace period; zombie detection uses real process liveness instead of tmux-session existence
   - `generate_wrapped_command` key-escaping (`\`, `"`, `$`, backtick) is only kept for tmux mode; the process path spawns `bash -c` directly
   - `gflowd up` falls back to hosting the daemon as a detached process (pidfile-tracked) when tmux is unavailable; `gflowd down` / `gflowd status` handle both modes

--- a/docs/src/getting-started/installation.md
+++ b/docs/src/getting-started/installation.md
@@ -9,20 +9,20 @@ The Python package name is `runqd`. It provides `gflowd`, `gbatch`, `gqueue`, `g
 ## Prerequisites
 
 - **Operating System**: Linux
-- **tmux**: Optional (only needed for `gflowd up`/attach workflows and the legacy tmux executor; job execution itself runs as plain child processes by default)
+- **tmux**: Required for the default job executor and for `gflowd up`/attach workflows. The tmux-free `process` executor remains available as an opt-in via `[executor] type = "process"`
 - **NVIDIA GPU / drivers**: Only required for GPU scheduling
 
 ### Installing Prerequisites
 
 ::: code-group
 ```bash [Ubuntu/Debian]
-# tmux is optional; install it only if you want tmux-hosted daemon / attach support
+# tmux is required for the default tmux job executor and tmux-hosted daemon
 sudo apt-get update
 sudo apt-get install tmux
 ```
 
 ```bash [Fedora/RHEL]
-# tmux is optional; install it only if you want tmux-hosted daemon / attach support
+# tmux is required for the default tmux job executor and tmux-hosted daemon
 sudo dnf install tmux
 ```
 :::

--- a/docs/src/reference/gflowd-reference.md
+++ b/docs/src/reference/gflowd-reference.md
@@ -119,7 +119,7 @@ Hosting: systemd user service (gflowd.service).
 Version:   0.4.17
 PID:       3628801
 Uptime:    25h57m21s
-Executor:  process
+Executor:  tmux
 GPUs:      8 total, 8 available
 ```
 

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -204,17 +204,17 @@ Choose how job payloads are executed.
 
 ```toml
 [executor]
-type = "process" # or "tmux"
+type = "tmux" # or "process"
 ```
 
-- **`process`** (default, no tmux required): each job runs as a detached child
+- **`tmux`** (default): each job runs in a detached tmux session with
+  terminal key injection. Enables interactive inspection via `gjob attach`
+  and `gjob close-sessions`.
+- **`process`** (opt-in, no tmux required): each job runs as a detached child
   process group (`setsid`), with stdout/stderr redirected to
   `logs/<job_id>.log`. Cancellation SIGTERMs the whole process group and
   escalates to SIGKILL after a grace period; zombie detection uses real
-  process liveness.
-- **`tmux`** (legacy): each job runs in a detached tmux session with
-  terminal key injection. Enables interactive inspection via `gjob attach`
-  and `gjob close-sessions`.
+  process liveness. Not yet considered stable.
 
 ## Project Tracking
 

--- a/docs/src/zh-CN/reference/gflowd-reference.md
+++ b/docs/src/zh-CN/reference/gflowd-reference.md
@@ -119,7 +119,7 @@ Hosting: systemd user service (gflowd.service).
 Version:   0.4.17
 PID:       3628801
 Uptime:    25h57m21s
-Executor:  process
+Executor:  tmux
 GPUs:      8 total, 8 available
 ```
 

--- a/docs/src/zh-CN/user-guide/configuration.md
+++ b/docs/src/zh-CN/user-guide/configuration.md
@@ -201,14 +201,14 @@ gctl reserve create --user alice --gpus 2 --start "2026-02-01 14:00" --duration 
 
 ```toml
 [executor]
-type = "process" # 或 "tmux"
+type = "tmux" # 或 "process"
 ```
 
-- **`process`**（默认，无需 tmux）：每个作业作为独立子进程组（`setsid`）运行，
-  stdout/stderr 重定向到 `logs/<job_id>.log`。取消作业时对整个进程组发送
-  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。
-- **`tmux`**（旧版）：每个作业在独立的 tmux session 中运行，通过终端按键注入
+- **`tmux`**（默认）：每个作业在独立的 tmux session 中运行，通过终端按键注入
   命令。支持 `gjob attach` 和 `gjob close-sessions` 交互式检查。
+- **`process`**（可选，无需 tmux）：每个作业作为独立子进程组（`setsid`）运行，
+  stdout/stderr 重定向到 `logs/<job_id>.log`。取消作业时对整个进程组发送
+  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。尚未稳定。
 
 ## 项目追踪
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -235,18 +235,18 @@ impl QuotaConfig {
 #[serde(rename_all = "lowercase")]
 pub enum ExecutorType {
     /// Spawn a detached child process group (setsid) with stdio redirected to
-    /// the job log file. The default; requires no tmux.
-    #[default]
+    /// the job log file. Opt-in; requires no tmux.
     Process,
     /// Legacy tmux session + terminal key injection. Enables `gjob attach`
-    /// and `gjob close-sessions` for running jobs.
+    /// and `gjob close-sessions` for running jobs. The default; requires tmux.
+    #[default]
     Tmux,
 }
 
 /// Job executor settings, configured via the `[executor]` table in `gflow.toml`.
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct ExecutorConfig {
-    /// Which executor to use for job execution: "process" (default) or "tmux".
+    /// Which executor to use for job execution: "tmux" (default) or "process".
     #[serde(default)]
     pub r#type: ExecutorType,
 }
@@ -254,14 +254,14 @@ pub struct ExecutorConfig {
 impl Default for ExecutorConfig {
     fn default() -> Self {
         Self {
-            r#type: ExecutorType::Process,
+            r#type: ExecutorType::Tmux,
         }
     }
 }
 
 impl ExecutorConfig {
     fn is_default(value: &Self) -> bool {
-        value.r#type == ExecutorType::Process
+        value.r#type == ExecutorType::Tmux
     }
 }
 
@@ -668,8 +668,8 @@ cv-team = { max_running_gpus = 8, max_queued_jobs = 100 }
     }
 
     #[test]
-    fn executor_defaults_to_process() {
-        assert_eq!(ExecutorConfig::default().r#type, ExecutorType::Process);
+    fn executor_defaults_to_tmux() {
+        assert_eq!(ExecutorConfig::default().r#type, ExecutorType::Tmux);
     }
 
     #[test]

--- a/src/core/executor.rs
+++ b/src/core/executor.rs
@@ -25,10 +25,11 @@ pub enum ExecutionStatus {
 
 /// Abstraction over how a job's payload is actually executed.
 ///
-/// The default implementation (`ProcessExecutor`) spawns a detached child
-/// process group (`setsid`) and redirects its stdio to the job log file.
-/// The legacy `TmuxExecutor` keeps the terminal-injection behaviour and is
-/// available as an opt-in via `[executor] type = "tmux"`.
+/// The default implementation (selected when no `[executor]` config is set) is
+/// the `TmuxExecutor`, which runs each job in a detached tmux session with
+/// terminal key injection. The `ProcessExecutor` spawns a detached child
+/// process group (`setsid`) and redirects its stdio to the job log file; it is
+/// available as an opt-in via `[executor] type = "process"`.
 ///
 /// All methods other than `execute` have default no-op implementations so
 /// that mock executors used in tests only need to implement `execute`.

--- a/src/core/info.rs
+++ b/src/core/info.rs
@@ -27,7 +27,7 @@ pub struct DaemonStatus {
     pub pid: u32,
     /// Seconds since the daemon started.
     pub uptime_secs: u64,
-    /// Job executor backend: "process" (default) or "tmux".
+    /// Job executor backend: "tmux" (default) or "process".
     pub executor: String,
     /// Number of detected GPU slots.
     pub gpu_total: usize,
@@ -42,7 +42,7 @@ pub struct SchedulerInfo {
     pub allowed_gpu_indices: Option<Vec<u32>>,
     /// Strategy used when allocating GPUs for new jobs.
     pub gpu_allocation_strategy: GpuAllocationStrategy,
-    /// Job executor backend: "process" (default) or "tmux".
+    /// Job executor backend: "tmux" (default) or "process".
     #[serde(default)]
     pub executor: String,
 }

--- a/src/multicall/gflowd/server.rs
+++ b/src/multicall/gflowd/server.rs
@@ -47,7 +47,7 @@ pub async fn run(config: gflow::config::Config) -> anyhow::Result<()> {
     }
     let gpu_poll_interval = Duration::from_secs(gpu_poll_interval_secs);
 
-    // Inject the configured job executor (default: process; tmux opt-in)
+    // Inject the configured job executor (default: tmux; process opt-in)
     let executor: Box<dyn Executor> = match config.executor.r#type {
         ExecutorType::Process => Box::new(ProcessExecutor::new()),
         ExecutorType::Tmux => Box::new(TmuxExecutor),

--- a/tests/daemon_e2e_test.rs
+++ b/tests/daemon_e2e_test.rs
@@ -146,7 +146,9 @@ struct SandboxOpts {
 }
 
 impl TestSandbox {
-    /// Default sandbox: tmux-hosted daemon, process executor (the default).
+    /// Default sandbox: tmux-hosted daemon, explicit process executor (opt-in;
+    /// avoids creating tmux job sessions so the suite stays clean on shared
+    /// tmux servers; the tmux backend is covered by dedicated tests).
     fn new() -> Option<Self> {
         Self::with_opts(SandboxOpts {
             tmux_hosted: true,
@@ -1351,7 +1353,7 @@ async fn process_executor_detects_zombie_when_process_dies_without_reporting() {
 }
 
 /// Acceptance: `[executor] type` switches between backends. The tmux backend
-/// creates a job session; the process backend (default) creates none.
+/// creates a job session; the process backend (opt-in) creates none.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn executor_type_config_selects_backend() {
     // tmux backend: job gets a tmux session (daemon hosted directly, but the


### PR DESCRIPTION
## 变更内容

将默认作业执行器从 process 改回 tmux（对应 issue W-288）。process 执行器（W-173）尚未稳定，因此无 [executor] type 配置时默认使用 tmux；process 仍可通过 [executor] type = "process" 显式选用。

### 核心改动
- src/config.rs：ExecutorType::default() / ExecutorConfig::default() 改为 Tmux；ExecutorConfig::is_default() 以 Tmux 为可序列化默认值；单测 executor_defaults_to_tmux 同步更新
- src/core/executor.rs / src/core/info.rs / src/multicall/gflowd/server.rs：文档注释与配置注入注释改为 tmux 默认、process 可选
- docs（EN + zh-CN）：configuration.md 执行器章节、installation.md 前置依赖（tmux 恢复为默认所需）、gflowd-reference.md 示例输出
- CHANGELOG.md：Unreleased 中 process 执行器条目改为 experimental opt-in，默认改为 tmux

### 测试
- e2e 沙箱保持显式 process 执行器（避免在共享 tmux server 上泄漏 gjob-* 会话，影响对 tmux 全局状态敏感的单元测试）；tmux 后端仍由 executor_type_config_selects_backend 及 tmux 专项 e2e 覆盖
- 本地验证：cargo test --locked --all-features --workspace 全部通过（365 lib + 3 + 13 e2e + 17 + 17 integration）；cargo fmt --check、cargo clippy -D warnings、cargo doc -D warnings、web lint+build 均通过
- 冒烟验证：无 [executor] 配置启动 daemon，GET /info 返回 executor = tmux

Closes W-288