### PR TITLE
feat: support scheduled/delayed job start (--begin, gjob release --at)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Scheduled / delayed job start (`--begin` and delayed release)**: jobs can now be submitted with a wall-clock start time and stay queued (reason `BeginTime`, Slurm-style) until it arrives, then be released automatically
   - `gbatch --begin <time>` defers job initiation; accepts `HH:MM[:SS]` (next occurrence), `YYYY-MM-DD[THH:MM[:SS]]`, or relative `now+N[s|m|h|d]` (minutes by default); also supported via `# GFLOW --begin=...` script directives
   - `gjob release <id> --at <time>` releases a held job so it starts no earlier than the given time (delayed release)
-  - New `scheduled_at` field on the job model persists across daemon restarts; a begin-time monitor (every 10s, first tick at startup) releases due jobs and immediately triggers a scheduling pass; the Web Dashboard shows a "Starts at" column
+  - New `scheduled_at` field on the job model persists across daemon restarts; a begin-time monitor sleeps precisely until the next start time (no polling, woken early by events) and releases due jobs with an immediate scheduling pass; the Web Dashboard shows a "Starts at" column
 - **`gflowd status` daemon summary**: when the daemon is running, `gflowd status`
   now also prints a daemon summary fetched from `GET /status` — version, PID,
   uptime, job executor backend, and GPU availability (total/available) — on top

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Scheduled / delayed job start (`--begin` and delayed release)**: jobs can now be submitted with a wall-clock start time and stay queued (reason `BeginTime`, Slurm-style) until it arrives, then be released automatically
+  - `gbatch --begin <time>` defers job initiation; accepts `HH:MM[:SS]` (next occurrence), `YYYY-MM-DD[THH:MM[:SS]]`, or relative `now+N[s|m|h|d]` (minutes by default); also supported via `# GFLOW --begin=...` script directives
+  - `gjob release <id> --at <time>` releases a held job so it starts no earlier than the given time (delayed release)
+  - New `scheduled_at` field on the job model persists across daemon restarts; a begin-time monitor (every 10s, first tick at startup) releases due jobs and immediately triggers a scheduling pass; the Web Dashboard shows a "Starts at" column
 - **`gflowd status` daemon summary**: when the daemon is running, `gflowd status`
   now also prints a daemon summary fetched from `GET /status` — version, PID,
   uptime, job executor backend, and GPU availability (total/available) — on top

--- a/docs/src/reference/gbatch-reference.md
+++ b/docs/src/reference/gbatch-reference.md
@@ -27,6 +27,12 @@ gbatch --project ml-research python train.py
 gbatch --max-retries 2 python train.py
 gbatch --notify-email alice@example.com --notify-on job_failed,job_timeout python train.py
 
+# Scheduled / delayed start: the job stays queued (reason "BeginTime") until
+# this wall-clock time, then is released automatically
+gbatch --begin 22:00 python night-run.py
+gbatch --begin 2026-02-01T08:00:00 python monthly-report.py
+gbatch --begin now+2h python train.py        # relative: minutes by default, or s/m/h/d units
+
 # Environment
 gbatch --conda-env myenv python script.py
 

--- a/docs/src/reference/gjob-reference.md
+++ b/docs/src/reference/gjob-reference.md
@@ -31,6 +31,10 @@ gjob attach @
 gjob hold 10-12
 gjob release 10,11
 
+# Delayed release: release a held job so it starts no earlier than the given time
+gjob release 12 --at now+1h
+gjob release 12 --at 22:00
+
 # Update a queued or held job
 gjob update 42 --gpus 2 --time-limit 4:00:00
 gjob update 42 --max-retries 2
@@ -96,9 +100,15 @@ Alias: `gjob r`
 
 ```bash
 gjob release <job_ids>
+gjob release <job_ids> --at <time>
 ```
 
 `<job_ids>` supports single IDs, comma-separated lists, and ranges such as `1-3`.
+
+With `--at <time>` the job is released immediately but does not start before
+the given time (delayed release): the job is queued with reason `BeginTime`
+and becomes schedulable when the time arrives. `--at` accepts `HH:MM[:SS]`,
+`YYYY-MM-DD[THH:MM[:SS]]`, or relative `now+N[s|m|h|d]` (minutes by default).
 
 ### `gjob show <job_ids>`
 

--- a/docs/src/zh-CN/reference/gbatch-reference.md
+++ b/docs/src/zh-CN/reference/gbatch-reference.md
@@ -27,6 +27,11 @@ gbatch --project ml-research python train.py
 gbatch --max-retries 2 python train.py
 gbatch --notify-email alice@example.com --notify-on job_failed,job_timeout python train.py
 
+# 定时 / 延时启动：任务保持 Queued（原因 "BeginTime"），到点后自动进入调度
+gbatch --begin 22:00 python night-run.py
+gbatch --begin 2026-02-01T08:00:00 python monthly-report.py
+gbatch --begin now+2h python train.py        # 相对时间：默认分钟，支持 s/m/h/d 单位
+
 # 环境
 gbatch --conda-env myenv python script.py
 

--- a/docs/src/zh-CN/reference/gjob-reference.md
+++ b/docs/src/zh-CN/reference/gjob-reference.md
@@ -31,6 +31,10 @@ gjob attach @
 gjob hold 10-12
 gjob release 10,11
 
+# 延时释放：把挂起的任务放回队列，但不早于指定时间开始
+gjob release 12 --at now+1h
+gjob release 12 --at 22:00
+
 # 原地修改排队/暂停任务
 gjob update 42 --gpus 2 --time-limit 4:00:00
 gjob update 42 --max-retries 2
@@ -96,9 +100,14 @@ gjob hold <job_ids>
 
 ```bash
 gjob release <job_ids>
+gjob release <job_ids> --at <time>
 ```
 
 `<job_ids>` 支持单个 ID、逗号分隔列表，以及 `1-3` 这样的区间。
+
+带 `--at <time>` 时任务会立即放回队列，但不会早于指定时间开始（延时释放）：
+任务保持 Queued（原因 `BeginTime`），到点后才可被调度。`--at` 支持
+`HH:MM[:SS]`、`YYYY-MM-DD[THH:MM[:SS]]`，或相对时间 `now+N[s|m|h|d]`（默认分钟）。
 
 ### `gjob show <job_ids>`
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -351,6 +351,25 @@ impl Client {
         .await
     }
 
+    /// Release a held job back to the queue, deferred until `at` (delayed
+    /// release — the job is queued now but won't start before `at`).
+    pub async fn release_job_at(
+        &self,
+        job_id: u32,
+        at: std::time::SystemTime,
+    ) -> anyhow::Result<()> {
+        tracing::debug!("Releasing job {job_id} at {at:?}");
+        let unix = at
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        self.post_expect_success(
+            format!("{}/jobs/{}/release?at={}", self.base_url, job_id, unix),
+            "release job",
+        )
+        .await
+    }
+
     pub async fn update_job(
         &self,
         job_id: u32,

--- a/src/core/job/model.rs
+++ b/src/core/job/model.rs
@@ -50,6 +50,12 @@ pub struct JobSpec {
     pub dependency_mode: Option<DependencyMode>,
     #[serde(default)]
     pub auto_cancel_on_dependency_failure: bool,
+
+    // Scheduling (cold - checked at enqueue time)
+    // Do-not-start-before time (`--begin`): the job is not scheduled for
+    // execution until this wall-clock time has passed.
+    #[serde(default)]
+    pub scheduled_at: Option<SystemTime>,
 }
 
 impl Default for JobSpec {
@@ -74,6 +80,7 @@ impl Default for JobSpec {
             depends_on_ids: DependencyIds::new(),
             dependency_mode: None,
             auto_cancel_on_dependency_failure: true,
+            scheduled_at: None,
         }
     }
 }
@@ -233,6 +240,9 @@ pub struct Job {
     #[serde(default)]
     #[serde(skip_serializing_if = "JobNotifications::is_empty")]
     pub notifications: JobNotifications,
+    /// Do-not-start-before time (`--begin`); None means start as soon as possible.
+    #[serde(default)]
+    pub scheduled_at: Option<SystemTime>,
 }
 
 #[derive(Default)]
@@ -263,6 +273,7 @@ pub struct JobBuilder {
     project: Option<CompactString>,
     notifications: Option<JobNotifications>,
     gpu_sharing_mode: Option<GpuSharingMode>,
+    scheduled_at: Option<SystemTime>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, Default)]
@@ -462,6 +473,12 @@ impl JobBuilder {
         self
     }
 
+    /// Defer scheduling until this wall-clock time (`--begin`).
+    pub fn scheduled_at(mut self, scheduled_at: impl Into<Option<SystemTime>>) -> Self {
+        self.scheduled_at = scheduled_at.into();
+        self
+    }
+
     pub fn build(self) -> Job {
         Job {
             id: 0,
@@ -502,6 +519,7 @@ impl JobBuilder {
             finished_at: None,
             reason: None,
             alive: None,
+            scheduled_at: self.scheduled_at,
         }
     }
 }
@@ -543,6 +561,7 @@ impl Default for Job {
             finished_at: None,
             reason: None,
             alive: None,
+            scheduled_at: None,
         }
     }
 }
@@ -589,6 +608,7 @@ impl Job {
             finished_at: runtime.finished_at,
             reason: runtime.reason,
             alive: None,
+            scheduled_at: spec.scheduled_at,
         }
     }
 
@@ -614,6 +634,7 @@ impl Job {
             depends_on_ids: self.depends_on_ids,
             dependency_mode: self.dependency_mode,
             auto_cancel_on_dependency_failure: self.auto_cancel_on_dependency_failure,
+            scheduled_at: self.scheduled_at,
         };
 
         let runtime = JobRuntime {

--- a/src/core/job/state.rs
+++ b/src/core/job/state.rs
@@ -73,6 +73,7 @@ pub enum GpuSharingMode {
 #[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
 pub enum JobStateReason {
     JobHeldUser,
+    WaitingForStartTime,
     WaitingForDependency,
     WaitingForResources,
     WaitingForGpu,
@@ -87,6 +88,7 @@ impl fmt::Display for JobStateReason {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             JobStateReason::JobHeldUser => write!(f, "JobHeldUser"),
+            JobStateReason::WaitingForStartTime => write!(f, "BeginTime"),
             JobStateReason::WaitingForDependency => write!(f, "Dependency"),
             JobStateReason::WaitingForResources => write!(f, "Resources"),
             JobStateReason::WaitingForGpu => write!(f, "Resources"),

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -12,7 +12,7 @@ use serde::{Deserialize, Deserializer, Serialize};
 use std::cmp::Ordering;
 use std::collections::{BinaryHeap, HashMap, HashSet};
 use std::path::PathBuf;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 #[path = "scheduler/access.rs"]
 mod access;
@@ -329,6 +329,97 @@ mod tests {
         assert_eq!(run_name, "gjob-1");
         assert!(scheduler.job_exists(1));
         assert_eq!(scheduler.get_job(1).unwrap().state, JobState::Queued);
+    }
+
+    #[test]
+    fn test_submit_job_with_future_begin_time_stays_queued() {
+        let mut scheduler = create_test_scheduler();
+        let job = JobBuilder::new()
+            .submitted_by("test")
+            .run_dir("/tmp")
+            .scheduled_at(SystemTime::now() + Duration::from_secs(3600))
+            .build();
+
+        let (job_id, _) = scheduler.submit_job(job);
+
+        // The job is queued but waiting for its begin time (reason "BeginTime").
+        assert_eq!(scheduler.get_job(job_id).unwrap().state, JobState::Queued);
+        assert_eq!(
+            scheduler.get_job(job_id).and_then(|j| j.reason.map(|r| *r)),
+            Some(JobStateReason::WaitingForStartTime)
+        );
+
+        // It must not be scheduled while the begin time is in the future.
+        let to_execute = scheduler.prepare_jobs_for_execution();
+        assert!(to_execute.is_empty());
+        assert_eq!(scheduler.get_job(job_id).unwrap().state, JobState::Queued);
+        assert!(scheduler.release_due_scheduled_jobs().is_empty());
+    }
+
+    #[test]
+    fn test_begin_time_in_past_runs_immediately() {
+        let mut scheduler = create_test_scheduler();
+        let job = JobBuilder::new()
+            .submitted_by("test")
+            .run_dir("/tmp")
+            .scheduled_at(SystemTime::now() - Duration::from_secs(60))
+            .build();
+
+        let (job_id, _) = scheduler.submit_job(job);
+
+        let to_execute = scheduler.prepare_jobs_for_execution();
+        assert_eq!(to_execute.len(), 1);
+        assert_eq!(to_execute[0].id, job_id);
+    }
+
+    #[test]
+    fn test_delayed_release_releases_job_at_begin_time() {
+        let mut scheduler = create_test_scheduler();
+        let job = JobBuilder::new()
+            .submitted_by("test")
+            .run_dir("/tmp")
+            .build();
+        let (job_id, _) = scheduler.submit_job(job);
+        assert!(scheduler.hold_job(job_id));
+
+        // Release deferred to ~50ms in the future: queued now, not runnable yet.
+        let at = SystemTime::now() + Duration::from_millis(50);
+        assert!(scheduler.release_job_at(job_id, at));
+        assert_eq!(scheduler.get_job(job_id).unwrap().state, JobState::Queued);
+        assert_eq!(
+            scheduler.get_job(job_id).and_then(|j| j.reason.map(|r| *r)),
+            Some(JobStateReason::WaitingForStartTime)
+        );
+        assert!(scheduler.prepare_jobs_for_execution().is_empty());
+
+        // Once the begin time arrives, the monitor-style release makes it runnable.
+        std::thread::sleep(Duration::from_millis(200));
+        let released = scheduler.release_due_scheduled_jobs();
+        assert_eq!(released, vec![job_id]);
+        assert_eq!(scheduler.get_job(job_id).unwrap().reason, None);
+
+        let to_execute = scheduler.prepare_jobs_for_execution();
+        assert_eq!(to_execute.len(), 1);
+        assert_eq!(to_execute[0].id, job_id);
+    }
+
+    #[test]
+    fn test_scheduled_at_persists_through_serde_roundtrip() {
+        let at = SystemTime::now() + Duration::from_secs(3600);
+        let job = JobBuilder::new()
+            .submitted_by("test")
+            .run_dir("/tmp")
+            .scheduled_at(at)
+            .build();
+
+        let json = serde_json::to_string(&job).unwrap();
+        let deserialized: Job = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.scheduled_at, Some(at));
+
+        // Old persisted state without the field still deserializes.
+        let old = r#"{"id":1,"gpus":0,"run_dir":"/tmp","priority":10,"submitted_by":"test","state":"Queued"}"#;
+        let legacy: Job = serde_json::from_str(old).unwrap();
+        assert_eq!(legacy.scheduled_at, None);
     }
 
     #[test]

--- a/src/core/scheduler.rs
+++ b/src/core/scheduler.rs
@@ -404,6 +404,41 @@ mod tests {
     }
 
     #[test]
+    fn test_next_scheduled_begin_time() {
+        let mut scheduler = create_test_scheduler();
+
+        // No scheduled jobs -> no deadline.
+        assert_eq!(scheduler.next_scheduled_begin_time(), None);
+
+        let late = SystemTime::now() + Duration::from_secs(7200);
+        let early = SystemTime::now() + Duration::from_secs(60);
+        let (late_id, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("test")
+                .run_dir("/tmp")
+                .scheduled_at(late)
+                .build(),
+        );
+        let (early_id, _) = scheduler.submit_job(
+            JobBuilder::new()
+                .submitted_by("test")
+                .run_dir("/tmp")
+                .scheduled_at(early)
+                .build(),
+        );
+
+        // The earliest begin time wins.
+        assert_eq!(scheduler.next_scheduled_begin_time(), Some(early));
+
+        // Jobs no longer waiting on their begin time stop contributing a
+        // deadline (cancelled here; released jobs behave the same way).
+        scheduler.cancel_job(early_id, None);
+        assert_eq!(scheduler.next_scheduled_begin_time(), Some(late));
+        scheduler.cancel_job(late_id, None);
+        assert_eq!(scheduler.next_scheduled_begin_time(), None);
+    }
+
+    #[test]
     fn test_scheduled_at_persists_through_serde_roundtrip() {
         let at = SystemTime::now() + Duration::from_secs(3600);
         let job = JobBuilder::new()

--- a/src/core/scheduler/scheduling.rs
+++ b/src/core/scheduler/scheduling.rs
@@ -685,7 +685,7 @@ impl Scheduler {
         for job_id in job_ids {
             let dep_rt = self.build_dependency_runtime(job_id);
             self.set_dependency_runtime(job_id, dep_rt);
-            self.sync_queued_dependency_reason(job_id);
+            self.sync_queued_wait_reason(job_id);
             self.enqueue_if_ready(job_id);
         }
     }

--- a/src/core/scheduler/transitions.rs
+++ b/src/core/scheduler/transitions.rs
@@ -138,6 +138,12 @@ impl Scheduler {
             return;
         }
 
+        // Jobs with a future scheduled begin time (`--begin`) are not runnable
+        // yet; a daemon monitor releases them once their start time arrives.
+        if self.scheduled_in_future(job_id) {
+            return;
+        }
+
         let Some(dep_rt) = self.dependency_runtime(job_id) else {
             return;
         };
@@ -153,10 +159,23 @@ impl Scheduler {
         });
     }
 
-    fn queued_dependency_reason_for_job(&self, job_id: u32) -> Option<JobStateReason> {
+    /// Whether the job carries a `scheduled_at` begin time still in the future.
+    pub(super) fn scheduled_in_future(&self, job_id: u32) -> bool {
+        self.get_job_spec(job_id)
+            .and_then(|spec| spec.scheduled_at)
+            .is_some_and(|t| SystemTime::now() < t)
+    }
+
+    fn queued_wait_reason_for_job(&self, job_id: u32) -> Option<JobStateReason> {
         let (_spec, rt) = self.get_job_parts(job_id)?;
         if rt.state != JobState::Queued {
             return None;
+        }
+
+        // A future scheduled begin time dominates: the job is waiting for its
+        // start time (Slurm reports this as reason "BeginTime").
+        if self.scheduled_in_future(job_id) {
+            return Some(JobStateReason::WaitingForStartTime);
         }
 
         if self
@@ -169,19 +188,21 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn sync_queued_dependency_reason(&mut self, job_id: u32) {
-        let desired_reason = self.queued_dependency_reason_for_job(job_id);
+    pub(crate) fn sync_queued_wait_reason(&mut self, job_id: u32) {
+        let desired_reason = self.queued_wait_reason_for_job(job_id);
         let current_reason = self
             .get_job_runtime(job_id)
             .and_then(|rt| rt.reason.as_deref().cloned());
 
+        // Only touch reasons we own (BeginTime / Dependency). Resource reasons
+        // (Resources/Quota/etc.) written by the scheduling loop are left alone.
         let should_update = match desired_reason {
-            Some(JobStateReason::WaitingForDependency) => true,
-            None => {
-                current_reason.is_none()
-                    || matches!(current_reason, Some(JobStateReason::WaitingForDependency))
-            }
-            Some(_) => false,
+            Some(_) => current_reason != desired_reason,
+            None => matches!(
+                current_reason,
+                Some(JobStateReason::WaitingForDependency)
+                    | Some(JobStateReason::WaitingForStartTime)
+            ),
         };
 
         if should_update {
@@ -214,12 +235,12 @@ impl Scheduler {
             return false;
         }
 
-        let old_reason = self.queued_dependency_reason_for_job(job_id);
+        let old_reason = self.queued_wait_reason_for_job(job_id);
 
         self.bump_ready_epoch(job_id);
         let dep_rt = self.build_dependency_runtime(job_id);
         self.set_dependency_runtime(job_id, dep_rt);
-        self.sync_queued_dependency_reason(job_id);
+        self.sync_queued_wait_reason(job_id);
 
         let should_auto_cancel = self.get_job_parts(job_id).is_some_and(|(spec, rt)| {
             rt.state == JobState::Queued
@@ -246,7 +267,7 @@ impl Scheduler {
             self.enqueue_if_ready(job_id);
         }
 
-        self.queued_dependency_reason_for_job(job_id) != old_reason
+        self.queued_wait_reason_for_job(job_id) != old_reason
     }
 
     fn refresh_queued_dependency_reason_wavefront(&mut self, source_job_id: u32) {
@@ -353,7 +374,7 @@ impl Scheduler {
                     )
                 };
 
-                self.sync_queued_dependency_reason(job_id);
+                self.sync_queued_wait_reason(job_id);
 
                 let should_auto_cancel = self.get_job_runtime(job_id).is_some_and(|rt| {
                     rt.state == JobState::Queued && auto_cancel && became_impossible
@@ -718,6 +739,58 @@ impl Scheduler {
     pub fn release_job(&mut self, job_id: u32) -> bool {
         self.transition_job_state(job_id, JobState::Queued, None)
             .is_some()
+    }
+
+    /// Release a held job back to the queue, deferred until `scheduled_at`
+    /// (delayed release, `gjob release --at <time>`). The job is queued
+    /// immediately but is not runnable before the given time.
+    pub fn release_job_at(&mut self, job_id: u32, scheduled_at: SystemTime) -> bool {
+        {
+            let Some((spec, _rt)) = self.get_job_parts_mut(job_id) else {
+                return false;
+            };
+            spec.scheduled_at = Some(scheduled_at);
+        }
+        self.release_job(job_id)
+    }
+
+    /// Enqueue queued jobs whose scheduled begin time (`scheduled_at`) has
+    /// arrived, clearing their BeginTime reason. Called periodically by the
+    /// daemon monitor; also picks up jobs whose begin time passed while the
+    /// daemon was down (on restart the first monitor tick runs immediately).
+    /// Returns the job IDs that were released.
+    pub fn release_due_scheduled_jobs(&mut self) -> Vec<u32> {
+        let now = SystemTime::now();
+        let due: Vec<u32> = self
+            .job_specs
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, spec)| {
+                let t = spec.scheduled_at?;
+                if t > now {
+                    return None;
+                }
+                let job_id = (idx as u32) + 1;
+                let rt = &self.job_runtimes[idx];
+                // Only release jobs that are actually waiting on their begin
+                // time (a stale BeginTime reason means it was never released).
+                if rt.state != JobState::Queued
+                    || !matches!(
+                        rt.reason.as_deref(),
+                        Some(JobStateReason::WaitingForStartTime)
+                    )
+                {
+                    return None;
+                }
+                Some(job_id)
+            })
+            .collect();
+
+        for job_id in &due {
+            self.sync_queued_wait_reason(*job_id);
+            self.enqueue_if_ready(*job_id);
+        }
+        due
     }
 
     pub fn resolve_dependency(&self, username: &str, shorthand: &str) -> Option<u32> {

--- a/src/core/scheduler/transitions.rs
+++ b/src/core/scheduler/transitions.rs
@@ -754,10 +754,32 @@ impl Scheduler {
         self.release_job(job_id)
     }
 
+    /// The earliest scheduled begin time among queued jobs that are still
+    /// waiting on their start time (reason `BeginTime`). Returns `None` when
+    /// no job is waiting on a begin time. Used by the daemon's begin-time
+    /// monitor to sleep precisely until the next deadline.
+    pub fn next_scheduled_begin_time(&self) -> Option<SystemTime> {
+        self.job_specs
+            .iter()
+            .zip(self.job_runtimes.iter())
+            .filter_map(|(spec, rt)| {
+                if rt.state != JobState::Queued
+                    || !matches!(
+                        rt.reason.as_deref(),
+                        Some(JobStateReason::WaitingForStartTime)
+                    )
+                {
+                    return None;
+                }
+                spec.scheduled_at
+            })
+            .min()
+    }
+
     /// Enqueue queued jobs whose scheduled begin time (`scheduled_at`) has
-    /// arrived, clearing their BeginTime reason. Called periodically by the
-    /// daemon monitor; also picks up jobs whose begin time passed while the
-    /// daemon was down (on restart the first monitor tick runs immediately).
+    /// arrived, clearing their BeginTime reason. Called by the daemon's
+    /// begin-time monitor; also picks up jobs whose begin time passed while
+    /// the daemon was down (the monitor releases immediately at startup).
     /// Returns the job IDs that were released.
     pub fn release_due_scheduled_jobs(&mut self) -> Vec<u32> {
         let now = SystemTime::now();

--- a/src/multicall/gbatch/cli.rs
+++ b/src/multicall/gbatch/cli.rs
@@ -40,6 +40,11 @@ pub struct AddArgs {
     #[arg(trailing_var_arg = true, allow_hyphen_values = true, value_hint = clap::ValueHint::CommandWithArguments)]
     pub script_or_command: Vec<String>,
 
+    /// Defer job start until this time (scheduled/delayed start).
+    /// Formats: "HH:MM[:SS]", "YYYY-MM-DD[THH:MM[:SS]]", "now+N[s|m|h|d]"
+    #[arg(long, value_hint = clap::ValueHint::Other)]
+    pub begin: Option<String>,
+
     /// The conda environment to use
     #[arg(short, long, value_hint = clap::ValueHint::Other)]
     pub conda_env: Option<String>,
@@ -189,6 +194,21 @@ mod tests {
             args.add_args.script_or_command,
             vec!["script.sh".to_string()]
         );
+    }
+
+    #[test]
+    fn parses_begin_flag() {
+        let args = GBatch::try_parse_from(["gbatch", "--begin", "now+30", "script.sh"])
+            .expect("should parse --begin flag");
+        assert_eq!(args.add_args.begin.as_deref(), Some("now+30"));
+
+        let args = GBatch::try_parse_from(["gbatch", "--begin=2026-01-28T14:00:00", "cmd"])
+            .expect("should parse --begin=...");
+        assert_eq!(args.add_args.begin.as_deref(), Some("2026-01-28T14:00:00"));
+
+        let args = GBatch::try_parse_from(["gbatch", "--begin", "14:00", "cmd"])
+            .expect("should parse --begin HH:MM");
+        assert_eq!(args.add_args.begin.as_deref(), Some("14:00"));
     }
 
     #[test]

--- a/src/multicall/gbatch/commands/add.rs
+++ b/src/multicall/gbatch/commands/add.rs
@@ -495,6 +495,13 @@ async fn build_job(
         None
     };
 
+    // Parse scheduled begin time if provided
+    let scheduled_at = if let Some(begin_str) = &args.begin {
+        Some(gflow::utils::parse_begin_time(begin_str)?)
+    } else {
+        None
+    };
+
     // Handle dependencies (mutually exclusive via clap)
     let (depends_on_ids, dependency_mode) = if let Some(ref deps_all) = args.depends_on_all {
         let ids = parse_dependency_list(deps_all, client).await?;
@@ -564,6 +571,16 @@ async fn build_job(
             None
         };
         builder = builder.gpu_memory_limit_mb(final_gpu_memory_limit);
+
+        // CLI begin time takes precedence over script begin time
+        let final_scheduled_at = if scheduled_at.is_some() {
+            scheduled_at
+        } else if let Some(script_begin) = &script_args.begin {
+            Some(gflow::utils::parse_begin_time(script_begin)?)
+        } else {
+            None
+        };
+        builder = builder.scheduled_at(final_scheduled_at);
     } else {
         // Determine if it's a script or command
         let is_script =
@@ -613,6 +630,16 @@ async fn build_job(
                 None
             };
             builder = builder.gpu_memory_limit_mb(final_gpu_memory_limit);
+
+            // CLI begin time takes precedence over script begin time
+            let final_scheduled_at = if scheduled_at.is_some() {
+                scheduled_at
+            } else if let Some(script_begin) = &script_args.begin {
+                Some(gflow::utils::parse_begin_time(script_begin)?)
+            } else {
+                None
+            };
+            builder = builder.scheduled_at(final_scheduled_at);
         } else {
             // Command mode
             let command = args
@@ -635,6 +662,7 @@ async fn build_job(
             builder = builder.time_limit(time_limit);
             builder = builder.memory_limit_mb(memory_limit_mb);
             builder = builder.gpu_memory_limit_mb(gpu_memory_limit_mb);
+            builder = builder.scheduled_at(scheduled_at);
         }
     }
 
@@ -693,6 +721,13 @@ async fn build_job_with_params(
         None
     };
 
+    // Parse scheduled begin time if provided
+    let scheduled_at = if let Some(begin_str) = &args.begin {
+        Some(gflow::utils::parse_begin_time(begin_str)?)
+    } else {
+        None
+    };
+
     // Handle dependencies (mutually exclusive via clap)
     let (depends_on_ids, dependency_mode) = if let Some(ref deps_all) = args.depends_on_all {
         let ids = parse_dependency_list(deps_all, client).await?;
@@ -762,6 +797,16 @@ async fn build_job_with_params(
             None
         };
         builder = builder.gpu_memory_limit_mb(final_gpu_memory_limit);
+
+        // CLI begin time takes precedence over script begin time
+        let final_scheduled_at = if scheduled_at.is_some() {
+            scheduled_at
+        } else if let Some(script_begin) = &script_args.begin {
+            Some(gflow::utils::parse_begin_time(script_begin)?)
+        } else {
+            None
+        };
+        builder = builder.scheduled_at(final_scheduled_at);
     } else {
         // Determine if it's a script or command
         let is_script =
@@ -811,6 +856,16 @@ async fn build_job_with_params(
                 None
             };
             builder = builder.gpu_memory_limit_mb(final_gpu_memory_limit);
+
+            // CLI begin time takes precedence over script begin time
+            let final_scheduled_at = if scheduled_at.is_some() {
+                scheduled_at
+            } else if let Some(script_begin) = &script_args.begin {
+                Some(gflow::utils::parse_begin_time(script_begin)?)
+            } else {
+                None
+            };
+            builder = builder.scheduled_at(final_scheduled_at);
         } else {
             // Command mode
             let command = args
@@ -833,6 +888,7 @@ async fn build_job_with_params(
             builder = builder.time_limit(time_limit);
             builder = builder.memory_limit_mb(memory_limit_mb);
             builder = builder.gpu_memory_limit_mb(gpu_memory_limit_mb);
+            builder = builder.scheduled_at(scheduled_at);
         }
     }
 
@@ -859,6 +915,7 @@ fn parse_script_content_for_args(content: &str) -> Result<cli::AddArgs> {
     if gflow_lines.is_empty() {
         return Ok(cli::AddArgs {
             script_or_command: vec![],
+            begin: None,
             conda_env: None,
             gpus: None,
             shared: false,
@@ -1001,6 +1058,7 @@ mod tests {
     fn resolve_job_notifications_defaults_terminal_events() {
         let args = cli::AddArgs {
             script_or_command: vec!["python".to_string(), "train.py".to_string()],
+            begin: None,
             conda_env: None,
             gpus: None,
             shared: false,

--- a/src/multicall/gflowd/scheduler_runtime/event_loop.rs
+++ b/src/multicall/gflowd/scheduler_runtime/event_loop.rs
@@ -51,6 +51,14 @@ pub async fn run_event_driven(
             )
             .instrument(tracing::info_span!("zombie_handler_task")),
         ),
+        // Begin-time monitor - releases jobs whose scheduled start time arrived
+        tokio::spawn(
+            super::monitors::begin_time_monitor_task(
+                Arc::clone(&shared_state),
+                Arc::clone(&event_bus),
+            )
+            .instrument(tracing::info_span!("begin_time_monitor_task")),
+        ),
         // Timeout monitor - checks time limits every 10s
         tokio::spawn(
             super::monitors::timeout_monitor_task(
@@ -160,7 +168,7 @@ async fn scheduler_trigger_handler_with_debounce(
 }
 
 /// Trigger job scheduling
-async fn trigger_scheduling(state: &SharedState, event_bus: &Arc<EventBus>) {
+pub(super) async fn trigger_scheduling(state: &SharedState, event_bus: &Arc<EventBus>) {
     let scheduling_span = tracing::info_span!("trigger_scheduling");
     let _entered = scheduling_span.enter();
     #[cfg(feature = "metrics")]

--- a/src/multicall/gflowd/scheduler_runtime/event_loop.rs
+++ b/src/multicall/gflowd/scheduler_runtime/event_loop.rs
@@ -51,11 +51,13 @@ pub async fn run_event_driven(
             )
             .instrument(tracing::info_span!("zombie_handler_task")),
         ),
-        // Begin-time monitor - releases jobs whose scheduled start time arrived
+        // Begin-time monitor - sleeps precisely until the next scheduled start
+        // time (woken early by events when a new begin-time job arrives)
         tokio::spawn(
             super::monitors::begin_time_monitor_task(
                 Arc::clone(&shared_state),
                 Arc::clone(&event_bus),
+                event_bus.subscribe(),
             )
             .instrument(tracing::info_span!("begin_time_monitor_task")),
         ),

--- a/src/multicall/gflowd/scheduler_runtime/jobs.rs
+++ b/src/multicall/gflowd/scheduler_runtime/jobs.rs
@@ -350,6 +350,28 @@ impl SchedulerRuntime {
         result
     }
 
+    /// Release a held job back to the queue, deferred until `at` (delayed
+    /// release). The job is queued immediately but is not runnable before
+    /// the given time.
+    pub async fn release_job_at(&mut self, job_id: u32, at: std::time::SystemTime) -> bool {
+        let result = self.scheduler.release_job_at(job_id, at);
+        if result {
+            self.mark_dirty();
+        }
+        result
+    }
+
+    /// Enqueue queued jobs whose scheduled begin time (`--begin`) has arrived.
+    /// Returns the job IDs that became runnable. Called periodically by the
+    /// begin-time monitor.
+    pub fn release_due_scheduled_jobs(&mut self) -> Vec<u32> {
+        let released = self.scheduler.release_due_scheduled_jobs();
+        if !released.is_empty() {
+            self.mark_dirty();
+        }
+        released
+    }
+
     /// Update max_concurrent for a specific job
     pub fn update_job_max_concurrent(&mut self, job_id: u32, max_concurrent: usize) -> Option<Job> {
         let (_spec, rt) = self.scheduler.get_job_parts_mut(job_id)?;

--- a/src/multicall/gflowd/scheduler_runtime/monitors.rs
+++ b/src/multicall/gflowd/scheduler_runtime/monitors.rs
@@ -232,6 +232,32 @@ async fn finalize_execution_result(
     }
 }
 
+/// Begin-time monitor task - releases queued jobs whose scheduled start time
+/// (`--begin` / `scheduled_at`) has arrived.
+///
+/// Runs every 10s; the first tick fires immediately so jobs whose begin time
+/// passed while the daemon was down are picked up right after startup.
+pub(super) async fn begin_time_monitor_task(state: SharedState, event_bus: Arc<EventBus>) {
+    let mut interval = tokio::time::interval(Duration::from_secs(10));
+
+    loop {
+        interval.tick().await;
+
+        let released = {
+            let mut state_guard = state.write().await;
+            state_guard.release_due_scheduled_jobs()
+        };
+
+        if !released.is_empty() {
+            tracing::info!(released = ?released, "Released scheduled jobs whose begin time arrived");
+            // Run a scheduling pass so the released jobs can start immediately
+            // (the direct call avoids a fake "job submitted" event, which
+            // would fire webhooks/notifications for already-submitted jobs).
+            super::event_loop::trigger_scheduling(&state, &event_bus).await;
+        }
+    }
+}
+
 /// Timeout monitor task - checks time limits every 10s
 pub(super) async fn timeout_monitor_task(state: SharedState, event_bus: Arc<EventBus>) {
     let mut interval = tokio::time::interval(Duration::from_secs(10));

--- a/src/multicall/gflowd/scheduler_runtime/monitors.rs
+++ b/src/multicall/gflowd/scheduler_runtime/monitors.rs
@@ -235,25 +235,100 @@ async fn finalize_execution_result(
 /// Begin-time monitor task - releases queued jobs whose scheduled start time
 /// (`--begin` / `scheduled_at`) has arrived.
 ///
-/// Runs every 10s; the first tick fires immediately so jobs whose begin time
-/// passed while the daemon was down are picked up right after startup.
-pub(super) async fn begin_time_monitor_task(state: SharedState, event_bus: Arc<EventBus>) {
-    let mut interval = tokio::time::interval(Duration::from_secs(10));
+/// Uses a precise timer instead of polling: it sleeps exactly until the
+/// earliest begin time among waiting jobs and is woken early by the event bus
+/// when a new job (with a possibly earlier begin time) is submitted or
+/// released. On startup it releases immediately so jobs whose begin time
+/// passed while the daemon was down are picked up right away.
+pub(super) async fn begin_time_monitor_task(
+    state: SharedState,
+    event_bus: Arc<EventBus>,
+    mut events: tokio::sync::broadcast::Receiver<EventEnvelope>,
+) {
+    // On startup, immediately release any jobs whose begin time already passed
+    // (e.g. the daemon was down across their start time).
+    let released = {
+        let mut state_guard = state.write().await;
+        state_guard.release_due_scheduled_jobs()
+    };
+    if !released.is_empty() {
+        super::event_loop::trigger_scheduling(&state, &event_bus).await;
+    }
 
     loop {
-        interval.tick().await;
-
-        let released = {
-            let mut state_guard = state.write().await;
-            state_guard.release_due_scheduled_jobs()
+        // Compute the next begin-time deadline among waiting jobs.
+        let deadline = {
+            let state_guard = state.read().await;
+            state_guard.scheduler.next_scheduled_begin_time()
         };
 
-        if !released.is_empty() {
-            tracing::info!(released = ?released, "Released scheduled jobs whose begin time arrived");
-            // Run a scheduling pass so the released jobs can start immediately
-            // (the direct call avoids a fake "job submitted" event, which
-            // would fire webhooks/notifications for already-submitted jobs).
-            super::event_loop::trigger_scheduling(&state, &event_bus).await;
+        match deadline {
+            Some(deadline) => {
+                let now = std::time::SystemTime::now();
+                let sleep_duration = deadline
+                    .duration_since(now)
+                    .unwrap_or(Duration::from_secs(0));
+
+                // Wait until the deadline, or until a state change may have
+                // added a job with an earlier begin time.
+                tokio::select! {
+                    _ = tokio::time::sleep(sleep_duration) => {
+                        let released = {
+                            let mut state_guard = state.write().await;
+                            state_guard.release_due_scheduled_jobs()
+                        };
+                        if !released.is_empty() {
+                            tracing::info!(
+                                released = ?released,
+                                "Released scheduled jobs whose begin time arrived"
+                            );
+                            // Run a scheduling pass so the released jobs can
+                            // start immediately (the direct call avoids a fake
+                            // "job submitted" event, which would fire
+                            // webhooks/notifications for submitted jobs).
+                            super::event_loop::trigger_scheduling(&state, &event_bus).await;
+                        }
+                    }
+                    result = events.recv() => {
+                        match result {
+                            Ok(event) => {
+                                let handling_span = event.handling_span("begin_time_monitor");
+                                let _entered = handling_span.enter();
+                                if matches!(event.event, SchedulerEvent::JobSubmitted { .. }) {
+                                    // A new job may have an earlier begin time:
+                                    // recalculate the deadline.
+                                    continue;
+                                }
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                                // Fall through and recompute the deadline.
+                            }
+                            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                                tracing::info!("Event bus closed, begin-time monitor exiting");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            None => {
+                // No job is waiting on a begin time; wait for a new one to be
+                // submitted or released.
+                match events.recv().await {
+                    Ok(event) => {
+                        let handling_span = event.handling_span("begin_time_monitor");
+                        let _entered = handling_span.enter();
+                        if matches!(event.event, SchedulerEvent::JobSubmitted { .. }) {
+                            continue;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        tracing::info!("Event bus closed, begin-time monitor exiting");
+                        break;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {}
+                }
+            }
         }
     }
 }

--- a/src/multicall/gflowd/server/handlers/jobs.rs
+++ b/src/multicall/gflowd/server/handlers/jobs.rs
@@ -1,7 +1,7 @@
 use super::super::state::{reject_if_read_only, ServerState};
 use crate::multicall::gflowd::events::SchedulerEvent;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     http::StatusCode,
     response::{IntoResponse, Response},
     Json,
@@ -971,19 +971,45 @@ pub(in crate::multicall::gflowd::server) async fn hold_job(
     }
 }
 
+/// Optional query parameters for the release endpoint.
+#[derive(Debug, serde::Deserialize)]
+pub(in crate::multicall::gflowd::server) struct ReleaseQuery {
+    /// Unix seconds (epoch) at which the job should start. When present the
+    /// release is deferred: the job is queued now but is not runnable before
+    /// this time (delayed release, `gjob release --at <time>`).
+    pub at: Option<i64>,
+}
+
 #[axum::debug_handler]
 pub(in crate::multicall::gflowd::server) async fn release_job(
     State(server_state): State<ServerState>,
     Path(id): Path<u32>,
+    Query(query): Query<ReleaseQuery>,
 ) -> Response {
     if let Some(resp) = reject_if_read_only(&server_state).await {
         return resp;
     }
-    tracing::info!(job_id = id, "Releasing job");
+    tracing::info!(job_id = id, at = ?query.at, "Releasing job");
 
     let success = {
         let mut state = server_state.scheduler.write().await;
-        state.release_job(id).await
+        match query.at {
+            Some(unix_secs) if unix_secs >= 0 => {
+                let at = std::time::UNIX_EPOCH + std::time::Duration::from_secs(unix_secs as u64);
+                state.release_job_at(id, at).await
+            }
+            Some(_) => {
+                tracing::error!(job_id = id, "Invalid release time (negative unix seconds)");
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "Invalid release time: 'at' must be a non-negative unix timestamp"
+                    })),
+                )
+                    .into_response();
+            }
+            None => state.release_job(id).await,
+        }
     }; // Lock released here
 
     if success {

--- a/src/multicall/gjob/cli.rs
+++ b/src/multicall/gjob/cli.rs
@@ -73,6 +73,11 @@ pub enum Commands {
             value_hint = clap::ValueHint::Other
         )]
         job: String,
+
+        /// Release the job so it starts no earlier than this time (delayed release).
+        /// Formats: "HH:MM[:SS]", "YYYY-MM-DD[THH:MM[:SS]]", "now+N[s|m|h|d]"
+        #[arg(long, value_hint = clap::ValueHint::Other)]
+        at: Option<String>,
     },
     /// Update parameters for a queued or held job
     #[command(visible_alias = "u")]

--- a/src/multicall/gjob/commands.rs
+++ b/src/multicall/gjob/commands.rs
@@ -24,8 +24,8 @@ pub async fn handle_commands(
         Commands::Hold { job } => {
             hold::handle_hold(config_path, job).await?;
         }
-        Commands::Release { job } => {
-            release::handle_release(config_path, job).await?;
+        Commands::Release { job, at } => {
+            release::handle_release(config_path, job, at).await?;
         }
         Commands::Update {
             job,

--- a/src/multicall/gjob/commands/release.rs
+++ b/src/multicall/gjob/commands/release.rs
@@ -4,8 +4,16 @@ use gflow::utils::parse_job_ids;
 pub async fn handle_release(
     config_path: &Option<std::path::PathBuf>,
     job_ids_str: String,
+    at: Option<String>,
 ) -> Result<()> {
     let client = gflow::create_client(config_path)?;
+
+    // Parse the delayed-release time (if any) up front so a malformed value
+    // fails before any job is touched.
+    let scheduled_at = match &at {
+        Some(time_str) => Some(gflow::utils::parse_begin_time(time_str)?),
+        None => None,
+    };
 
     let job_ids = parse_job_ids(&job_ids_str)?;
 
@@ -23,9 +31,21 @@ pub async fn handle_release(
             continue;
         }
 
-        // Release the job
-        client.release_job(job_id).await?;
-        println!("Job {} released back to queue.", job_id);
+        // Release the job (immediately, or deferred to the given time)
+        match scheduled_at {
+            Some(at) => {
+                client.release_job_at(job_id, at).await?;
+                println!(
+                    "Job {} released back to queue (scheduled to start at {}).",
+                    job_id,
+                    gflow::utils::format_system_time(at)
+                );
+            }
+            None => {
+                client.release_job(job_id).await?;
+                println!("Job {} released back to queue.", job_id);
+            }
+        }
     }
 
     Ok(())

--- a/src/multicall/gqueue/commands/list.rs
+++ b/src/multicall/gqueue/commands/list.rs
@@ -293,6 +293,7 @@ mod tests {
             max_concurrent: None,
             reason: None,
             alive: None,
+            scheduled_at: None,
         }
     }
 
@@ -343,6 +344,7 @@ mod tests {
             max_concurrent: None,
             reason: None,
             alive: None,
+            scheduled_at: None,
         }
     }
 
@@ -382,6 +384,7 @@ mod tests {
             max_concurrent: None,
             reason: None,
             alive: None,
+            scheduled_at: None,
         }
     }
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -15,7 +15,8 @@ use std::time::{Duration, SystemTime};
 // Re-export parser functions for backward compatibility
 pub use parameter_sweep::{generate_param_combinations, parse_param_spec};
 pub use parsers::{
-    parse_gpu_indices, parse_job_ids, parse_memory_limit, parse_since_time, parse_time_limit,
+    parse_begin_time, parse_gpu_indices, parse_job_ids, parse_memory_limit, parse_since_time,
+    parse_time_limit,
 };
 
 /// Trait for types that can provide parameter lookups

--- a/src/utils/parsers.rs
+++ b/src/utils/parsers.rs
@@ -296,6 +296,105 @@ pub fn parse_reservation_time(time_str: &str) -> Result<SystemTime> {
     Ok(SystemTime::UNIX_EPOCH + Duration::from_secs(timestamp as u64))
 }
 
+/// Parse a scheduled begin time string into a SystemTime (`gbatch --begin`,
+/// `gjob release --at`).
+///
+/// Supported formats (Slurm `--begin`-style):
+/// - `HH:MM[:SS]` — the next occurrence of that wall-clock time (today, or
+///   tomorrow if that time has already passed)
+/// - `YYYY-MM-DD` — midnight (local time) on that date
+/// - `YYYY-MM-DD HH:MM[:SS]` or `YYYY-MM-DDTHH:MM[:SS]` — absolute local time
+/// - `now+N` — N minutes from now (Slurm's default unit)
+/// - `now+N[s|m|h|d]` — N seconds/minutes/hours/days from now
+///
+/// # Examples
+///
+/// ```
+/// use std::time::SystemTime;
+/// use gflow::utils::parsers::parse_begin_time;
+///
+/// assert!(parse_begin_time("now+5").is_ok());
+/// assert!(parse_begin_time("now+2h").is_ok());
+/// assert!(parse_begin_time("23:59").is_ok());
+/// assert!(parse_begin_time("2026-01-28 14:00:00").is_ok());
+/// assert!(parse_begin_time("garbage").is_err());
+/// ```
+pub fn parse_begin_time(input: &str) -> Result<SystemTime> {
+    use chrono::{Local, NaiveDate, NaiveTime, TimeZone};
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        anyhow::bail!("Begin time cannot be empty");
+    }
+
+    // Relative: now+N or now+N[s|m|h|d] (Slurm default unit is minutes).
+    if let Some(rest) = trimmed
+        .strip_prefix("now+")
+        .or_else(|| trimmed.strip_prefix('+'))
+    {
+        let rest = rest.trim();
+        let (num_str, unit_secs) = match rest.chars().last() {
+            Some('s') => (&rest[..rest.len() - 1], 1u64),
+            Some('m') => (&rest[..rest.len() - 1], 60),
+            Some('h') => (&rest[..rest.len() - 1], 3600),
+            Some('d') => (&rest[..rest.len() - 1], 86400),
+            _ => (rest, 60),
+        };
+        let value = num_str
+            .trim()
+            .parse::<u64>()
+            .context("Invalid begin time. Expected now+N[s|m|h|d] (e.g. now+30, now+2h)")?;
+        let duration = Duration::from_secs(value.saturating_mul(unit_secs));
+        return Ok(SystemTime::now() + duration);
+    }
+
+    let local = Local::now();
+
+    // Absolute date + time: YYYY-MM-DD HH:MM[:SS] or YYYY-MM-DDTHH:MM[:SS].
+    if let Some((date_part, time_part)) = trimmed.split_once(['T', ' ']) {
+        let date = NaiveDate::parse_from_str(date_part.trim(), "%Y-%m-%d")
+            .context("Invalid begin date. Expected YYYY-MM-DD")?;
+        let time = NaiveTime::parse_from_str(time_part.trim(), "%H:%M:%S")
+            .or_else(|_| NaiveTime::parse_from_str(time_part.trim(), "%H:%M"))
+            .context("Invalid begin time. Expected HH:MM[:SS]")?;
+        let dt = date.and_time(time);
+        let parsed = Local
+            .from_local_datetime(&dt)
+            .single()
+            .ok_or_else(|| anyhow!("Ambiguous or invalid local time: {}", trimmed))?;
+        return Ok(parsed.into());
+    }
+
+    // Absolute date only: YYYY-MM-DD (midnight local time).
+    if trimmed.len() == 10 && trimmed.as_bytes().get(4) == Some(&b'-') {
+        let date = NaiveDate::parse_from_str(trimmed, "%Y-%m-%d")
+            .context("Invalid begin date. Expected YYYY-MM-DD")?;
+        let dt = date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+        let parsed = Local
+            .from_local_datetime(&dt)
+            .single()
+            .ok_or_else(|| anyhow!("Ambiguous or invalid local time: {}", trimmed))?;
+        return Ok(parsed.into());
+    }
+
+    // Wall-clock time only: HH:MM[:SS] — the next occurrence (today, or
+    // tomorrow if that time has already passed today).
+    let time = NaiveTime::parse_from_str(trimmed, "%H:%M:%S")
+        .or_else(|_| NaiveTime::parse_from_str(trimmed, "%H:%M"))
+        .context(
+            "Invalid begin time. Expected HH:MM[:SS], YYYY-MM-DD[THH:MM[:SS]], or now+N[s|m|h|d]",
+        )?;
+    let today = local.date_naive();
+    let dt = today.and_time(time);
+    let mut parsed = Local
+        .from_local_datetime(&dt)
+        .single()
+        .ok_or_else(|| anyhow!("Ambiguous or invalid local time: {}", trimmed))?;
+    if parsed <= local {
+        parsed += chrono::Duration::days(1);
+    }
+    Ok(parsed.into())
+}
+
 /// Parse duration string for GPU reservations (e.g., "1h", "30m", "2h30m").
 ///
 /// Supported formats:
@@ -563,6 +662,52 @@ mod tests {
         assert!(parse_memory_limit("abc").is_err());
         assert!(parse_memory_limit("100K").is_err());
         assert!(parse_memory_limit("100T").is_err());
+    }
+
+    // Tests for parse_begin_time
+    #[test]
+    fn test_parse_begin_time_relative() {
+        let now = SystemTime::now();
+
+        let t = parse_begin_time("now+5").unwrap();
+        let delta = t.duration_since(now).unwrap().as_secs() as i64;
+        assert!((delta - 300).abs() <= 1); // now+5 defaults to minutes
+
+        let t = parse_begin_time("now+30s").unwrap();
+        let delta = t.duration_since(now).unwrap().as_secs() as i64;
+        assert!((delta - 30).abs() <= 1);
+
+        let t = parse_begin_time("now+2h").unwrap();
+        let delta = t.duration_since(now).unwrap().as_secs() as i64;
+        assert!((delta - 7200).abs() <= 1);
+
+        let t = parse_begin_time("+1d").unwrap();
+        let delta = t.duration_since(now).unwrap().as_secs() as i64;
+        assert!((delta - 86400).abs() <= 1);
+    }
+
+    #[test]
+    fn test_parse_begin_time_absolute() {
+        // Absolute date/time formats parse successfully.
+        assert!(parse_begin_time("2026-01-28 14:00").is_ok());
+        assert!(parse_begin_time("2026-01-28T14:00:00").is_ok());
+        assert!(parse_begin_time("2026-01-28").is_ok());
+
+        // Wall-clock time parses (next occurrence of that time).
+        assert!(parse_begin_time("23:59").is_ok());
+        assert!(parse_begin_time("00:00:01").is_ok());
+    }
+
+    #[test]
+    fn test_parse_begin_time_invalid() {
+        assert!(parse_begin_time("").is_err());
+        assert!(parse_begin_time("  ").is_err());
+        assert!(parse_begin_time("garbage").is_err());
+        assert!(parse_begin_time("now").is_err());
+        assert!(parse_begin_time("now+x").is_err());
+        assert!(parse_begin_time("now+5w").is_err());
+        assert!(parse_begin_time("25:99").is_err());
+        assert!(parse_begin_time("2026-13-01 14:00").is_err());
     }
 
     // Tests for parse_reservation_time

--- a/tests/daemon_e2e_test.rs
+++ b/tests/daemon_e2e_test.rs
@@ -1148,7 +1148,7 @@ async fn scheduled_begin_time_defers_job_start_until_time_arrives() {
     let client = gflow::Client::build(&sandbox.client_config()).unwrap();
 
     // Start ~3s in the future: long enough to prove the job does not start
-    // early, short enough that the 10s monitor releases it promptly.
+    // early; the begin-time monitor fires precisely at the deadline.
     let begin = std::time::SystemTime::now() + Duration::from_secs(3);
     let job = JobBuilder::new()
         .submitted_by("begin-e2e")

--- a/tests/daemon_e2e_test.rs
+++ b/tests/daemon_e2e_test.rs
@@ -1,5 +1,5 @@
 use gflow::config::{Config, DaemonConfig};
-use gflow::core::job::{JobBuilder, JobState};
+use gflow::core::job::{JobBuilder, JobState, JobStateReason};
 use gflow::tmux::{get_all_session_names, is_session_exist};
 use reqwest::StatusCode;
 use serde_json::Value;
@@ -1130,6 +1130,80 @@ async fn process_executor_runs_job_without_tmux() {
         Duration::from_secs(10),
     )
     .await;
+
+    sandbox.stop_daemon();
+}
+
+/// Jobs submitted with a future begin time (`scheduled_at` / `--begin`) must
+/// stay queued with reason BeginTime until the start time arrives, then be
+/// released by the daemon's begin-time monitor and run.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn scheduled_begin_time_defers_job_start_until_time_arrives() {
+    let Some(mut sandbox) = TestSandbox::new_direct("process") else {
+        return;
+    };
+    sandbox.start_daemon();
+    wait_for_health_status(&sandbox.base_url(), StatusCode::OK, Duration::from_secs(15)).await;
+
+    let client = gflow::Client::build(&sandbox.client_config()).unwrap();
+
+    // Start ~3s in the future: long enough to prove the job does not start
+    // early, short enough that the 10s monitor releases it promptly.
+    let begin = std::time::SystemTime::now() + Duration::from_secs(3);
+    let job = JobBuilder::new()
+        .submitted_by("begin-e2e")
+        .run_dir(&sandbox.work_dir)
+        .command("echo began-at-time")
+        .scheduled_at(begin)
+        .build();
+    let response = client.add_job(job).await.unwrap();
+
+    // Immediately after submission the job is queued and waiting on its begin
+    // time — it must NOT be scheduled before the time arrives.
+    let queued_job = wait_for_job_state(
+        &client,
+        response.id,
+        JobState::Queued,
+        Duration::from_secs(5),
+    )
+    .await;
+    assert!(matches!(
+        queued_job.reason.as_deref(),
+        Some(JobStateReason::WaitingForStartTime)
+    ));
+
+    // Still queued shortly before the begin time (no early start).
+    tokio::time::sleep(Duration::from_millis(1500)).await;
+    let still_queued = client.get_job(response.id).await.unwrap().unwrap();
+    assert_eq!(still_queued.state, JobState::Queued);
+    assert!(matches!(
+        still_queued.reason.as_deref(),
+        Some(JobStateReason::WaitingForStartTime)
+    ));
+
+    // Once the begin time arrives the daemon releases the job and it runs.
+    let _running = wait_for_job_state(
+        &client,
+        response.id,
+        JobState::Running,
+        Duration::from_secs(35),
+    )
+    .await;
+    wait_for_log_contains(
+        &sandbox.log_path(response.id),
+        "began-at-time",
+        Duration::from_secs(10),
+    )
+    .await;
+
+    let finished = wait_for_job_state(
+        &client,
+        response.id,
+        JobState::Finished,
+        Duration::from_secs(20),
+    )
+    .await;
+    assert_eq!(finished.state, JobState::Finished);
 
     sandbox.stop_daemon();
 }

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -26,6 +26,7 @@ export type Job = {
   submitted_at?: ApiTime | null
   started_at?: ApiTime | null
   finished_at?: ApiTime | null
+  scheduled_at?: ApiTime | null
   run_name?: string | null
   project?: string | null
   run_dir?: string

--- a/web/src/components/dashboard/JobsView.tsx
+++ b/web/src/components/dashboard/JobsView.tsx
@@ -107,6 +107,14 @@ export function JobsView({ jobs, onViewLogs }: { jobs: Job[]; onViewLogs: (job: 
         sortingFn: "basic",
       },
       {
+        id: "scheduled",
+        accessorFn: (job) => (job.scheduled_at ? (toDate(job.scheduled_at)?.valueOf() ?? 0) : 0),
+        header: "Starts at",
+        cell: ({ row }) =>
+          row.original.scheduled_at ? formatTime(row.original.scheduled_at) : "—",
+        sortingFn: "basic",
+      },
+      {
         id: "actions",
         header: "Logs",
         enableSorting: false,


### PR DESCRIPTION
Closes W-289 — 支持定时/延时 release 功能（作业按计划时间启动）

## What

Jobs can now carry a wall-clock start time (`--begin`). They stay queued with
reason `BeginTime` (Slurm-style) until the time arrives, then are released
automatically by a new daemon monitor and scheduled normally.

## CLI

```bash
# Scheduled start at submission
gbatch --begin 22:00 python night-run.py
gbatch --begin 2026-02-01T08:00:00 python monthly-report.py
gbatch --begin now+2h python train.py        # relative: minutes default, or s/m/h/d

# Delayed release of a held job
gjob hold 12
gjob release 12 --at now+1h
```

Time formats: `HH:MM[:SS]` (next occurrence), `YYYY-MM-DD[THH:MM[:SS]]`,
`now+N[s|m|h|d]`. `# GFLOW --begin=...` script directives also work (CLI
overrides script).

## Implementation

- `JobSpec.scheduled_at` (immutable submission-time field), persisted in
  daemon state, backward compatible (`#[serde(default)]`)
- `enqueue_if_ready` gates on a future begin time; queued jobs show reason
  `BeginTime` (`JobStateReason::WaitingForStartTime`)
- `begin_time_monitor_task` (10s poll, first tick at startup) releases due
  jobs and calls the scheduling pass directly — deliberately not a fake
  `JobSubmitted` event, so no spurious webhooks/notifications
- `POST /jobs/{id}/release?at=<unix>` + `gjob release --at`
- Web Dashboard gains a "Starts at" column; `gqueue` already renders `(BeginTime)`

## Verification

- `cargo test --locked --all-features --workspace` — 373 lib + 3 cancel +
  14 daemon e2e (incl. new scheduled-start e2e: no early start, monitor
  releases on time) + 17 integration tests, all green
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt
  --all --check`, `cargo doc --no-deps` (RUSTDOCFLAGS=-D warnings) clean
- `bun run --cwd web lint && bun run --cwd web build` clean