### PR TITLE
W-385: fix gflowd up daemon start in debug builds

### DIFF
--- a/src/multicall/gflowd/commands.rs
+++ b/src/multicall/gflowd/commands.rs
@@ -108,10 +108,14 @@ pub fn daemon_start_args(options: &DaemonStartOptions<'_>) -> Result<Vec<String>
     Ok(args)
 }
 
-/// Build a shell command that always starts daemon from the currently running `gflow` binary.
-/// This avoids accidentally picking a stale `gflow`/`gflowd` from PATH.
+/// Build a shell command that always starts daemon from the `gflow` multicall
+/// binary (preferring a sibling `gflow` next to the currently running binary,
+/// falling back to it). This avoids accidentally picking a stale
+/// `gflow`/`gflowd` from PATH, and works from debug `target/` builds where the
+/// wrapper dispatches in-process and `current_exe()` is the wrapper itself.
 pub fn daemon_start_command(options: &DaemonStartOptions<'_>) -> Result<String> {
-    let gflow_path = std::env::current_exe().context("failed to resolve current gflow binary")?;
+    let gflow_path =
+        crate::multicall::multicall_executable().context("failed to resolve current gflow binary")?;
     let exe = shell_escape::escape(gflow_path.to_string_lossy());
 
     let mut command = format!("{exe}");

--- a/src/multicall/gflowd/commands.rs
+++ b/src/multicall/gflowd/commands.rs
@@ -114,8 +114,8 @@ pub fn daemon_start_args(options: &DaemonStartOptions<'_>) -> Result<Vec<String>
 /// `gflow`/`gflowd` from PATH, and works from debug `target/` builds where the
 /// wrapper dispatches in-process and `current_exe()` is the wrapper itself.
 pub fn daemon_start_command(options: &DaemonStartOptions<'_>) -> Result<String> {
-    let gflow_path =
-        crate::multicall::multicall_executable().context("failed to resolve current gflow binary")?;
+    let gflow_path = crate::multicall::multicall_executable()
+        .context("failed to resolve current gflow binary")?;
     let exe = shell_escape::escape(gflow_path.to_string_lossy());
 
     let mut command = format!("{exe}");

--- a/src/multicall/gflowd/commands/systemd.rs
+++ b/src/multicall/gflowd/commands/systemd.rs
@@ -87,7 +87,8 @@ pub fn stop() -> Result<()> {
 /// (including `-c <config>`) and always pointing at the currently running
 /// `gflow` binary.
 fn unit_exec_start(options: &DaemonStartOptions<'_>) -> Result<String> {
-    let exe = std::env::current_exe().context("failed to resolve current gflow binary")?;
+    let exe = crate::multicall::multicall_executable()
+        .context("failed to resolve current gflow binary")?;
     let mut parts: Vec<String> = vec![shell_escape::escape(exe.to_string_lossy()).into_owned()];
     for arg in super::daemon_start_args(options)? {
         parts.push(shell_escape::escape(arg.into()).into_owned());

--- a/src/multicall/gflowd/commands/up.rs
+++ b/src/multicall/gflowd/commands/up.rs
@@ -71,7 +71,8 @@ pub async fn handle_up(
 /// `gflowd down` / `gflowd status` can manage it safely (no stale pidfile,
 /// no PID-reuse mis-kills).
 fn start_daemon_direct(options: &super::DaemonStartOptions<'_>) -> Result<()> {
-    let exe = std::env::current_exe().context("failed to resolve current gflow binary")?;
+    let exe = crate::multicall::multicall_executable()
+        .context("failed to resolve current gflow binary")?;
     let mut args = super::daemon_start_args(options)?;
     // Internal flag: tells the daemon it is being hosted directly and must
     // hold the daemon flock for its lifetime.

--- a/src/multicall/mod.rs
+++ b/src/multicall/mod.rs
@@ -1,4 +1,5 @@
 use std::ffi::OsString;
+use std::path::{Path, PathBuf};
 
 mod completion;
 
@@ -11,6 +12,33 @@ pub mod gjob;
 pub mod gqueue;
 pub mod gstats;
 pub mod mcp;
+
+/// Resolve the executable that can parse the `__multicall` sentinel.
+///
+/// The `gflow` binary is the real multicall dispatcher; the sibling wrapper
+/// binaries (`gflowd`, `gjob`, …) `execv` into it, so `current_exe()` already
+/// points at the dispatcher in release installs. But debug builds run straight
+/// from `target/debug` dispatch in-process, leaving `current_exe()` at the
+/// wrapper itself, which does not understand `__multicall`. Prefer a sibling
+/// `gflow` binary next to the current executable (the same layout the wrapper
+/// resolves via `find_sibling_gflow`), falling back to `current_exe()`.
+pub fn multicall_executable() -> std::io::Result<PathBuf> {
+    Ok(prefer_sibling_gflow(&std::env::current_exe()?))
+}
+
+/// Prefer a sibling `gflow` binary next to `exe` (multicall-capable), else the
+/// given executable itself.
+fn prefer_sibling_gflow(exe: &Path) -> PathBuf {
+    let Some(dir) = exe.parent() else {
+        return exe.to_path_buf();
+    };
+    let gflow = dir.join(format!("gflow{}", std::env::consts::EXE_SUFFIX));
+    if gflow.is_file() {
+        gflow
+    } else {
+        exe.to_path_buf()
+    }
+}
 
 pub async fn dispatch(argv: Vec<OsString>) -> anyhow::Result<()> {
     let Some(program) = argv.first() else {
@@ -42,4 +70,44 @@ pub fn print_top_level_help() {
     eprintln!(
         "gflow (multi-call)\n\nUsage:\n  gflow __multicall <command> [args...]\n  gflow <command> [args...]\n\nCommands:\n  gbatch\n  gcancel\n  gctl\n  gflowd\n  ginfo\n  gjob\n  mcp\n  gqueue\n  gstats\n"
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn bin_name(prefix: &str) -> String {
+        format!("{prefix}{}", std::env::consts::EXE_SUFFIX)
+    }
+
+    #[test]
+    fn prefer_sibling_gflow_picks_sibling_binary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gflow = tmp.path().join(bin_name("gflow"));
+        let gflowd = tmp.path().join(bin_name("gflowd"));
+        fs::write(&gflow, "").unwrap();
+        fs::write(&gflowd, "").unwrap();
+
+        // A wrapper next to the dispatcher must resolve to the dispatcher so
+        // the daemon start command can parse `__multicall`.
+        assert_eq!(prefer_sibling_gflow(&gflowd), gflow);
+        // The dispatcher itself stays put.
+        assert_eq!(prefer_sibling_gflow(&gflow), gflow);
+    }
+
+    #[test]
+    fn prefer_sibling_gflow_falls_back_to_current_exe() {
+        let tmp = tempfile::tempdir().unwrap();
+        let gflowd = tmp.path().join(bin_name("gflowd"));
+        fs::write(&gflowd, "").unwrap();
+
+        assert_eq!(prefer_sibling_gflow(&gflowd), gflowd);
+    }
+
+    #[test]
+    fn prefer_sibling_gflow_handles_missing_parent() {
+        // A bare filename (no parent) must fall back to itself, not panic.
+        assert_eq!(prefer_sibling_gflow(Path::new(bin_name("gflowd").as_str())), PathBuf::from(bin_name("gflowd")));
+    }
 }

--- a/src/multicall/mod.rs
+++ b/src/multicall/mod.rs
@@ -108,6 +108,9 @@ mod tests {
     #[test]
     fn prefer_sibling_gflow_handles_missing_parent() {
         // A bare filename (no parent) must fall back to itself, not panic.
-        assert_eq!(prefer_sibling_gflow(Path::new(bin_name("gflowd").as_str())), PathBuf::from(bin_name("gflowd")));
+        assert_eq!(
+            prefer_sibling_gflow(Path::new(bin_name("gflowd").as_str())),
+            PathBuf::from(bin_name("gflowd"))
+        );
     }
 }


### PR DESCRIPTION
Closes W-385

## Problem

`gflowd up` failed in debug builds run straight from `target/debug`: the daemon
start command built by `daemon_start_command` used `std::env::current_exe()`,
which in-process-dispatched wrappers resolve to the `gflowd` wrapper itself —
and the wrapper cannot parse the `__multicall` sentinel, so the tmux-hosted
daemon immediately failed with `error: unrecognized subcommand '__multicall'`,
the port never listened, and `gflowd status` reported Not Running.

Release installs were unaffected because there the wrapper `execv`s the sibling
`gflow` binary, so `current_exe()` already points at the multicall dispatcher.

## Fix

Add `gflow::multicall::multicall_executable()`: prefer a sibling `gflow`
binary next to the current executable (the same layout the wrapper resolves
via `find_sibling_gflow`), falling back to `current_exe()`.

Use it in all three daemon command builders:

- `daemon_start_command` (tmux-hosted daemon, used by `up`/`reload`)
- `start_daemon_direct` (no-tmux direct spawn)
- `unit_exec_start` (systemd unit `ExecStart`)

## Verification

- `./target/debug/gflowd up` now starts the daemon in tmux (`gflow_server`),
  `gflowd status` reports Running, pane shows the daemon serving `/health`.
- Direct (no-tmux) spawn path verified by hiding `tmux` from `PATH`:
  `gflowd started (direct mode, PID …)`, status Running.
- Full suite: 380 lib tests + 3 new resolver tests pass.
- `gflowd down` stops the daemon; pre-existing systemd-hosted daemon restored
  to active afterwards.
