### PR TITLE
W-416: fix clippy needless-bool in reservation filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   automatic terminal-width fitting.
 
 ### Fixed
+- **CI: fix `clippy::needless-bool` in reservation filtering**: simplify the
+  active-only reservation predicate so the nightly smoke check passes with
+  warnings denied.
 - **gqueue: long fields no longer break the table layout**: on a terminal,
   tables are truncated to fit the terminal width (widest columns first,
   `…` suffix), so long `COMMAND` values stay on one line; piped or

--- a/src/core/scheduler/reservations.rs
+++ b/src/core/scheduler/reservations.rs
@@ -135,11 +135,7 @@ impl Scheduler {
                 }
 
                 // Active only filter
-                if active_only && !r.is_active(now) {
-                    return false;
-                }
-
-                true
+                !(active_only && !r.is_active(now))
             })
             .collect()
     }


### PR DESCRIPTION
Closes W-416

Summary:
- Simplify the reservation active-only filter to return its boolean predicate directly.
- Record the CI lint fix in CHANGELOG.md.

Tests:
- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo test --locked --all-features --workspace