### PR TITLE
fix(executor): activate conda envs correctly in process executor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,17 +59,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses (column, global, and row sorting).
 
 ### Fixed
-- **gflowd: conda envs now activate correctly under the process executor**: the
-  runner is a non-interactive, non-login `bash -c`, so conda's shell init from
-  user rc files never ran and `conda activate` failed ("conda: command not
-  found" or "Run 'conda init' before 'conda activate'"). The executor now
-  locates a conda installation (checks the daemon's `$CONDA_EXE`, `$PATH`,
-  `$CONDA_PREFIX`, then common locations like `~/miniconda3`, `/opt/conda`)
-  and sources its `etc/profile.d/conda.sh` before activating; when no
-  installation is found the job fails fast with an explanatory error. The
-  conda env name and script path are now shell-quoted, so env names or paths
-  containing spaces/special characters no longer break (or inject into) the
-  runner command.
+- **gflowd: conda envs now activate correctly in both executors**: the
+  process executor runs jobs in a non-interactive, non-login `bash -c`, so
+  conda's shell init from user rc files never ran and `conda activate`
+  failed ("conda: command not found" or "Run 'conda init' before 'conda
+  activate'"). The daemon now locates a conda installation (checks
+  `$CONDA_EXE`, `conda` on `$PATH`, `$CONDA_PREFIX`, and common locations
+  like `~/miniconda3`, `/opt/conda`; `<root>/bin` and `<root>/condabin`
+  entry points are both recognized, and symlinks are resolved) and sources
+  its `etc/profile.d/conda.sh` before activating; the tmux executor reuses
+  the same logic. When no installation is found the job fails fast with an
+  explanatory error that is also written to the job log. The conda env name
+  and script path are shell-quoted in both executors, so env names or
+  paths containing spaces/special characters no longer break (or inject
+  into) the job command.
 - **web: job log dialog fixes**: the dialog actually renders wide now (the
   default `sm:max-w-lg` was overriding the intended width, so logs showed in
   a 512px box); tail auto-follow is fixed — the view pins to the bottom on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uses (column, global, and row sorting).
 
 ### Fixed
+- **gflowd: conda envs now activate correctly under the process executor**: the
+  runner is a non-interactive, non-login `bash -c`, so conda's shell init from
+  user rc files never ran and `conda activate` failed ("conda: command not
+  found" or "Run 'conda init' before 'conda activate'"). The executor now
+  locates a conda installation (checks the daemon's `$CONDA_EXE`, `$PATH`,
+  `$CONDA_PREFIX`, then common locations like `~/miniconda3`, `/opt/conda`)
+  and sources its `etc/profile.d/conda.sh` before activating; when no
+  installation is found the job fails fast with an explanatory error. The
+  conda env name and script path are now shell-quoted, so env names or paths
+  containing spaces/special characters no longer break (or inject into) the
+  runner command.
 - **web: job log dialog fixes**: the dialog actually renders wide now (the
   default `sm:max-w-lg` was overriding the intended width, so logs showed in
   a 512px box); tail auto-follow is fixed — the view pins to the bottom on

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -219,7 +219,12 @@ type = "tmux" # or "process"
   process group (`setsid`), with stdout/stderr redirected to
   `logs/<job_id>.log`. Cancellation SIGTERMs the whole process group and
   escalates to SIGKILL after a grace period; zombie detection uses real
-  process liveness. Not yet considered stable.
+  process liveness. Jobs with a `--conda-env` source the located conda
+  installation's `etc/profile.d/conda.sh` before `conda activate` — the
+  daemon's `$CONDA_EXE`, `$PATH`, `$CONDA_PREFIX` and common install
+  locations (`~/miniconda3`, `/opt/conda`, ...) are checked; if no conda
+  installation is found the job fails fast with an explanatory error.
+  Not yet considered stable.
 
 ## Project Tracking
 

--- a/docs/src/user-guide/configuration.md
+++ b/docs/src/user-guide/configuration.md
@@ -219,12 +219,15 @@ type = "tmux" # or "process"
   process group (`setsid`), with stdout/stderr redirected to
   `logs/<job_id>.log`. Cancellation SIGTERMs the whole process group and
   escalates to SIGKILL after a grace period; zombie detection uses real
-  process liveness. Jobs with a `--conda-env` source the located conda
-  installation's `etc/profile.d/conda.sh` before `conda activate` — the
-  daemon's `$CONDA_EXE`, `$PATH`, `$CONDA_PREFIX` and common install
-  locations (`~/miniconda3`, `/opt/conda`, ...) are checked; if no conda
-  installation is found the job fails fast with an explanatory error.
-  Not yet considered stable.
+  process liveness. Not yet considered stable.
+
+Both executors apply `--conda-env` the same way: before running the job the
+daemon locates a conda installation (checking `$CONDA_EXE`, `conda` on
+`$PATH`, `$CONDA_PREFIX`, and common install locations such as `~/miniconda3`
+or `/opt/conda`, recognizing both `<root>/bin` and `<root>/condabin` entry
+points), then sources its `etc/profile.d/conda.sh` and runs
+`conda activate <env>`. If no conda installation is found the job fails fast
+with an explanatory error, which is also written to the job log.
 
 ## Project Tracking
 

--- a/docs/src/zh-CN/user-guide/configuration.md
+++ b/docs/src/zh-CN/user-guide/configuration.md
@@ -212,11 +212,14 @@ type = "tmux" # 或 "process"
   命令。支持 `gjob attach` 和 `gjob close-sessions` 交互式检查。
 - **`process`**（可选，无需 tmux）：每个作业作为独立子进程组（`setsid`）运行，
   stdout/stderr 重定向到 `logs/<job_id>.log`。取消作业时对整个进程组发送
-  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。带 `--conda-env`
-  的作业会先定位 conda 安装（检查守护进程的 `$CONDA_EXE`、`$PATH`、
-  `$CONDA_PREFIX` 及常见安装位置，如 `~/miniconda3`、`/opt/conda`）并 source
-  其 `etc/profile.d/conda.sh`，然后执行 `conda activate`；找不到 conda 时
-  作业会快速失败并给出明确报错。尚未稳定。
+  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。尚未稳定。
+
+两种执行器应用 `--conda-env` 的方式一致：运行作业前，守护进程先定位 conda
+安装（检查 `$CONDA_EXE`、`$PATH` 上的 `conda`、`$CONDA_PREFIX`，以及常见安装
+位置如 `~/miniconda3`、`/opt/conda`，同时识别 `<root>/bin` 与 `<root>/condabin`
+两种入口），然后 source 其 `etc/profile.d/conda.sh` 并执行
+`conda activate <env>`。找不到 conda 安装时作业会快速失败并给出明确报错，
+该原因也会写入作业日志。
 
 ## 项目追踪
 

--- a/docs/src/zh-CN/user-guide/configuration.md
+++ b/docs/src/zh-CN/user-guide/configuration.md
@@ -212,7 +212,11 @@ type = "tmux" # 或 "process"
   命令。支持 `gjob attach` 和 `gjob close-sessions` 交互式检查。
 - **`process`**（可选，无需 tmux）：每个作业作为独立子进程组（`setsid`）运行，
   stdout/stderr 重定向到 `logs/<job_id>.log`。取消作业时对整个进程组发送
-  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。尚未稳定。
+  SIGTERM，宽限期后升级为 SIGKILL；僵尸检测基于真实进程活性。带 `--conda-env`
+  的作业会先定位 conda 安装（检查守护进程的 `$CONDA_EXE`、`$PATH`、
+  `$CONDA_PREFIX` 及常见安装位置，如 `~/miniconda3`、`/opt/conda`）并 source
+  其 `etc/profile.d/conda.sh`，然后执行 `conda activate`；找不到 conda 时
+  作业会快速失败并给出明确报错。尚未稳定。
 
 ## 项目追踪
 

--- a/src/multicall/gflowd/executor.rs
+++ b/src/multicall/gflowd/executor.rs
@@ -4,8 +4,10 @@ use gflow::core::job::{Job, JobState};
 use gflow::utils::substitute_parameters;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::env;
 use std::fs;
 use std::io::Write;
+use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -201,7 +203,7 @@ impl ProcessExecutor {
 
         if let Some(script) = &job.script {
             if let Some(script_str) = script.to_str() {
-                user_command.push_str(&format!("bash {script_str}"));
+                user_command.push_str(&format!("bash {}", shell_escape::escape(script_str.into())));
             }
         } else if let Some(cmd) = &job.command {
             let substituted = substitute_parameters(cmd, &job.parameters)?;
@@ -211,10 +213,124 @@ impl ProcessExecutor {
         }
 
         if let Some(conda_env) = &job.conda_env {
-            user_command = format!("conda activate {conda_env} && {user_command}");
+            user_command = format!(
+                "{} && {}",
+                Self::conda_activation_command(job, conda_env)?,
+                user_command
+            );
         }
 
         Ok(user_command)
+    }
+
+    /// Build the shell fragment that activates `conda_env` inside the runner.
+    ///
+    /// The runner is a non-interactive, non-login `bash -c`, so it never loads
+    /// the user's rc files and `conda activate` (a shell function installed by
+    /// conda's init) is unavailable. We therefore locate a conda installation
+    /// ourselves and source its init script before activating.
+    fn conda_activation_command(job: &Job, conda_env: &str) -> Result<String> {
+        let root = Self::locate_conda_root().with_context(|| {
+            format!(
+                "Job {} needs conda environment '{}' but no conda installation was found. \
+                 gflowd checked $CONDA_EXE, $PATH, $CONDA_PREFIX, and common install locations \
+                 ($HOME/miniconda3, $HOME/anaconda3, /opt/conda, ...)",
+                job.id, conda_env
+            )
+        })?;
+        let init_script = root.join("etc/profile.d/conda.sh");
+        Ok(format!(
+            "source {} && conda activate {}",
+            shell_escape::escape(init_script.to_string_lossy().into_owned().into()),
+            shell_escape::escape(conda_env.into())
+        ))
+    }
+
+    /// Locate the root of a conda installation, i.e. the directory containing
+    /// `etc/profile.d/conda.sh`. The runner inherits the daemon's environment,
+    /// which is all we can rely on. Detection order:
+    /// 1. `$CONDA_EXE` (set when the daemon started with a conda env active)
+    /// 2. a `conda` executable on `$PATH`
+    /// 3. `$CONDA_PREFIX` and its parents (covers envs nested under the root)
+    /// 4. well-known install locations under `$HOME`, `/opt`, `/usr`
+    #[cfg(not(windows))]
+    fn locate_conda_root() -> Option<PathBuf> {
+        Self::locate_conda_root_impl(":")
+    }
+
+    #[cfg(windows)]
+    fn locate_conda_root() -> Option<PathBuf> {
+        Self::locate_conda_root_impl(";")
+    }
+
+    fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
+        fn has_conda_init(root: &Path) -> bool {
+            root.join("etc/profile.d/conda.sh").is_file()
+        }
+
+        fn root_of_exe(exe: &Path) -> Option<PathBuf> {
+            let bin = exe.parent()?;
+            if bin.file_name()?.to_str() != Some("bin") {
+                return None;
+            }
+            Some(bin.parent()?.to_path_buf())
+        }
+
+        if let Ok(exe) = env::var("CONDA_EXE") {
+            if let Some(root) = root_of_exe(Path::new(&exe)) {
+                if has_conda_init(&root) {
+                    return Some(root);
+                }
+            }
+        }
+
+        if let Ok(paths) = env::var("PATH") {
+            for dir in paths.split(path_sep) {
+                if dir.is_empty() {
+                    continue;
+                }
+                let exe = Path::new(dir).join("conda");
+                if let Some(root) = root_of_exe(&exe) {
+                    if has_conda_init(&root) {
+                        return Some(root);
+                    }
+                }
+            }
+        }
+
+        if let Ok(prefix) = env::var("CONDA_PREFIX") {
+            let mut candidate = PathBuf::from(prefix);
+            for _ in 0..3 {
+                if has_conda_init(&candidate) {
+                    return Some(candidate);
+                }
+                match candidate.parent() {
+                    Some(parent) => candidate = parent.to_path_buf(),
+                    None => break,
+                }
+            }
+        }
+
+        let mut candidates: Vec<PathBuf> = Vec::new();
+        if let Ok(home) = env::var("HOME") {
+            for name in [
+                "miniconda3",
+                "miniforge3",
+                "anaconda3",
+                "mambaforge",
+                "conda",
+            ] {
+                candidates.push(Path::new(&home).join(name));
+            }
+        }
+        for base in ["/opt", "/usr/local", "/usr/share"] {
+            for name in ["conda", "miniconda3", "miniforge3", "anaconda3"] {
+                candidates.push(Path::new(base).join(name));
+            }
+        }
+        candidates
+            .into_iter()
+            .find(|candidate| has_conda_init(candidate))
     }
 
     /// Build the detached runner shell. The payload is executed by a nested
@@ -499,7 +615,7 @@ impl TmuxExecutor {
 
         if let Some(script) = &job.script {
             if let Some(script_str) = script.to_str() {
-                user_command.push_str(&format!("bash {script_str}"));
+                user_command.push_str(&format!("bash {}", shell_escape::escape(script_str.into())));
             }
         } else if let Some(cmd) = &job.command {
             // Apply parameter substitution
@@ -662,6 +778,150 @@ mod tests {
             wrapped,
             r#"bash -c "echo \"hello world\" && gcancel --finish 100 || gcancel --fail 100""#
         );
+    }
+
+    // ── conda environment tests ─────────────────────────────────────────────
+
+    /// Serializes tests that mutate conda-related process environment
+    /// variables (CONDA_EXE / CONDA_PREFIX / PATH / HOME).
+    static CONDA_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Run `f` with `vars` applied (None removes), restoring the previous
+    /// values afterwards. Holds the conda env lock for the whole duration.
+    fn with_conda_env_vars<T>(vars: &[(&str, Option<&str>)], f: impl FnOnce() -> T) -> T {
+        let _guard = CONDA_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let old: Vec<(String, Option<String>)> = vars
+            .iter()
+            .map(|(key, _)| (key.to_string(), std::env::var(key).ok()))
+            .collect();
+        for (key, value) in vars {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        let result = f();
+        for (key, value) in &old {
+            match value {
+                Some(value) => std::env::set_var(key, value),
+                None => std::env::remove_var(key),
+            }
+        }
+        result
+    }
+
+    /// Build a fake conda root: `<root>/bin/conda` plus
+    /// `<root>/etc/profile.d/conda.sh` (with optional extra init content).
+    fn make_fake_conda_root(tempdir: &std::path::Path, init_extra: &str) -> PathBuf {
+        let root = tempdir.join("fakeroot");
+        fs::create_dir_all(root.join("bin")).unwrap();
+        fs::create_dir_all(root.join("etc/profile.d")).unwrap();
+        fs::write(root.join("bin/conda"), "#!bin/sh\n").unwrap();
+        fs::write(
+            root.join("etc/profile.d/conda.sh"),
+            format!("# fake conda init\n{init_extra}\n"),
+        )
+        .unwrap();
+        root
+    }
+
+    #[test]
+    fn test_conda_root_located_from_conda_exe() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = make_fake_conda_root(tempdir.path(), "");
+        let found = with_conda_env_vars(
+            &[("CONDA_EXE", Some(root.join("bin/conda").to_str().unwrap()))],
+            ProcessExecutor::locate_conda_root,
+        )
+        .unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[test]
+    fn test_conda_root_located_from_path() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = make_fake_conda_root(tempdir.path(), "");
+        let found = with_conda_env_vars(
+            &[
+                ("CONDA_EXE", None),
+                ("CONDA_PREFIX", None),
+                ("PATH", Some(root.join("bin").to_str().unwrap())),
+            ],
+            ProcessExecutor::locate_conda_root,
+        )
+        .unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[test]
+    fn test_conda_root_located_from_conda_prefix_env() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = make_fake_conda_root(tempdir.path(), "");
+        // An activated nested env sets CONDA_PREFIX to the env dir, two levels
+        // below the root that actually contains the init script.
+        let env_dir = root.join("envs/nested");
+        fs::create_dir_all(&env_dir).unwrap();
+        let found = with_conda_env_vars(
+            &[
+                ("CONDA_EXE", None),
+                ("CONDA_PREFIX", Some(env_dir.to_str().unwrap())),
+                ("PATH", Some("/nonexistent-for-test")),
+            ],
+            ProcessExecutor::locate_conda_root,
+        )
+        .unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[test]
+    fn test_runner_command_sources_conda_init_before_activate() {
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = make_fake_conda_root(tempdir.path(), "");
+        let exe = root.join("bin/conda");
+        let job = job_with_command(777, "python --version");
+        let job = Job {
+            conda_env: Some("myenv; rm -rf /".into()),
+            ..job
+        };
+        let command = with_conda_env_vars(&[("CONDA_EXE", Some(exe.to_str().unwrap()))], || {
+            ProcessExecutor::build_user_command(&job)
+        })
+        .unwrap();
+        // The init script must be sourced before activation, and the env
+        // name must stay inside a single quoted word (no injection).
+        let expected_activation = format!(
+            "source {} && conda activate {}",
+            shell_escape::escape(
+                root.join("etc/profile.d/conda.sh")
+                    .to_string_lossy()
+                    .into_owned()
+                    .into()
+            ),
+            shell_escape::escape("myenv; rm -rf /".into())
+        );
+        assert!(
+            command.contains(&expected_activation),
+            "runner must source conda init before activating: {command}"
+        );
+        assert!(command.ends_with("&& python --version"));
+        let init_pos = command.find("conda.sh").unwrap();
+        let activate_pos = command.find("conda activate").unwrap();
+        assert!(init_pos < activate_pos);
+    }
+
+    #[test]
+    fn test_runner_command_quotes_script_path() {
+        let job = Job {
+            id: 42,
+            script: Some(PathBuf::from("/tmp/my script.sh").into()),
+            state: JobState::Queued,
+            run_dir: PathBuf::from("/tmp"),
+            ..Default::default()
+        };
+        let command = ProcessExecutor::build_user_command(&job).unwrap();
+        assert_eq!(command, "bash '/tmp/my script.sh'");
     }
 
     // ── live process tests (Linux) ─────────────────────────────────────────
@@ -850,6 +1110,68 @@ mod tests {
             }
             assert!(!executor.is_running(9101, None));
             assert!(!executor.is_running(9102, None));
+        })
+    }
+
+    #[test]
+    fn test_process_executor_conda_env_activation_end_to_end() {
+        with_isolated_data_dir(|| {
+            let tempdir = tempfile::tempdir().unwrap();
+            let init_extra = r#"
+conda() {
+    if [ "${1:-}" = "activate" ]; then
+        CONDA_DEFAULT_ENV="${2:-}"
+        export CONDA_DEFAULT_ENV
+        printf 'FAKE_CONDA_ACTIVATED %s\n' "${2:-}"
+        return 0
+    fi
+    return 0
+}
+"#;
+            let root = make_fake_conda_root(tempdir.path(), init_extra);
+            let exe = root.join("bin/conda");
+
+            let result = with_conda_env_vars(&[("CONDA_EXE", Some(exe.to_str().unwrap()))], || {
+                let executor = ProcessExecutor::new();
+                let job = Job {
+                    id: 9201,
+                    command: Some("true".into()),
+                    conda_env: Some("myenv".into()),
+                    state: JobState::Queued,
+                    run_dir: PathBuf::from("/tmp"),
+                    ..Default::default()
+                };
+                executor.execute(&job).unwrap();
+
+                let deadline = std::time::Instant::now() + Duration::from_secs(15);
+                let result = loop {
+                    if let Some(result) = executor
+                        .collect_finished()
+                        .into_iter()
+                        .find(|result| result.job_id == job.id)
+                    {
+                        break result;
+                    }
+                    assert!(
+                        std::time::Instant::now() < deadline,
+                        "runner did not finish"
+                    );
+                    std::thread::sleep(Duration::from_millis(50));
+                };
+
+                let log = std::fs::read_to_string(gflow::paths::get_log_file_path(9201).unwrap())
+                    .unwrap();
+                assert!(
+                    log.contains("FAKE_CONDA_ACTIVATED myenv"),
+                    "conda env was not activated in the runner; log: {log}"
+                );
+
+                executor.cleanup(&job);
+                result
+            });
+
+            assert_eq!(result.exit_code, Some(0));
+            assert!(result.succeeded());
         })
     }
 }

--- a/src/multicall/gflowd/executor.rs
+++ b/src/multicall/gflowd/executor.rs
@@ -215,124 +215,132 @@ impl ProcessExecutor {
         if let Some(conda_env) = &job.conda_env {
             user_command = format!(
                 "{} && {}",
-                Self::conda_activation_command(job, conda_env)?,
+                conda_activation_command(job, conda_env)?,
                 user_command
             );
         }
 
         Ok(user_command)
     }
-
-    /// Build the shell fragment that activates `conda_env` inside the runner.
-    ///
-    /// The runner is a non-interactive, non-login `bash -c`, so it never loads
-    /// the user's rc files and `conda activate` (a shell function installed by
-    /// conda's init) is unavailable. We therefore locate a conda installation
-    /// ourselves and source its init script before activating.
-    fn conda_activation_command(job: &Job, conda_env: &str) -> Result<String> {
-        let root = Self::locate_conda_root().with_context(|| {
-            format!(
-                "Job {} needs conda environment '{}' but no conda installation was found. \
+}
+/// Build the shell fragment that activates `conda_env` in the job shell.
+///
+/// Shared by both executors: the process runner is a non-interactive,
+/// non-login `bash -c` that never loads the user's rc files, and the tmux
+/// pane's interactive shell may not have conda initialized either. In both
+/// cases we locate a conda installation ourselves and source its init script
+/// before `conda activate` (a shell function installed by conda's init).
+fn conda_activation_command(job: &Job, conda_env: &str) -> Result<String> {
+    let root = locate_conda_root().with_context(|| {
+        format!(
+            "Job {} needs conda environment '{}' but no conda installation was found. \
                  gflowd checked $CONDA_EXE, $PATH, $CONDA_PREFIX, and common install locations \
                  ($HOME/miniconda3, $HOME/anaconda3, /opt/conda, ...)",
-                job.id, conda_env
-            )
-        })?;
-        let init_script = root.join("etc/profile.d/conda.sh");
-        Ok(format!(
-            "source {} && conda activate {}",
-            shell_escape::escape(init_script.to_string_lossy().into_owned().into()),
-            shell_escape::escape(conda_env.into())
-        ))
+            job.id, conda_env
+        )
+    })?;
+    let init_script = root.join("etc/profile.d/conda.sh");
+    Ok(format!(
+        "source {} && conda activate {}",
+        shell_escape::escape(init_script.to_string_lossy().into_owned().into()),
+        shell_escape::escape(conda_env.into())
+    ))
+}
+
+/// Locate the root of a conda installation, i.e. the directory containing
+/// `etc/profile.d/conda.sh`. The job shell inherits the daemon's environment,
+/// which is all we can rely on. Detection order:
+/// 1. `$CONDA_EXE` (set when the daemon started with a conda env active)
+/// 2. a `conda` executable on `$PATH`
+/// 3. `$CONDA_PREFIX` and its parents (covers envs nested under the root)
+/// 4. well-known install locations under `$HOME`, `/opt`, `/usr`
+#[cfg(not(windows))]
+fn locate_conda_root() -> Option<PathBuf> {
+    locate_conda_root_impl(":")
+}
+
+#[cfg(windows)]
+fn locate_conda_root() -> Option<PathBuf> {
+    locate_conda_root_impl(";")
+}
+
+fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
+    fn has_conda_init(root: &Path) -> bool {
+        root.join("etc/profile.d/conda.sh").is_file()
     }
 
-    /// Locate the root of a conda installation, i.e. the directory containing
-    /// `etc/profile.d/conda.sh`. The runner inherits the daemon's environment,
-    /// which is all we can rely on. Detection order:
-    /// 1. `$CONDA_EXE` (set when the daemon started with a conda env active)
-    /// 2. a `conda` executable on `$PATH`
-    /// 3. `$CONDA_PREFIX` and its parents (covers envs nested under the root)
-    /// 4. well-known install locations under `$HOME`, `/opt`, `/usr`
-    #[cfg(not(windows))]
-    fn locate_conda_root() -> Option<PathBuf> {
-        Self::locate_conda_root_impl(":")
-    }
-
-    #[cfg(windows)]
-    fn locate_conda_root() -> Option<PathBuf> {
-        Self::locate_conda_root_impl(";")
-    }
-
-    fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
-        fn has_conda_init(root: &Path) -> bool {
-            root.join("etc/profile.d/conda.sh").is_file()
+    /// Derive the installation root from a path to a `conda` executable.
+    /// Standard layouts put the entry point in `<root>/bin` (Python script)
+    /// or `<root>/condabin` (shell shim); symlinks are resolved first so a
+    /// `/usr/bin/conda` link still maps back to the real installation.
+    fn root_of_exe(exe: &Path) -> Option<PathBuf> {
+        let resolved = fs::canonicalize(exe).unwrap_or_else(|_| exe.to_path_buf());
+        let bin = resolved.parent()?;
+        let bin_name = bin.file_name()?.to_str()?;
+        if bin_name != "bin" && bin_name != "condabin" {
+            return None;
         }
+        Some(bin.parent()?.to_path_buf())
+    }
 
-        fn root_of_exe(exe: &Path) -> Option<PathBuf> {
-            let bin = exe.parent()?;
-            if bin.file_name()?.to_str() != Some("bin") {
-                return None;
+    if let Ok(exe) = env::var("CONDA_EXE") {
+        if let Some(root) = root_of_exe(Path::new(&exe)) {
+            if has_conda_init(&root) {
+                return Some(root);
             }
-            Some(bin.parent()?.to_path_buf())
         }
+    }
 
-        if let Ok(exe) = env::var("CONDA_EXE") {
-            if let Some(root) = root_of_exe(Path::new(&exe)) {
+    if let Ok(paths) = env::var("PATH") {
+        for dir in paths.split(path_sep) {
+            if dir.is_empty() {
+                continue;
+            }
+            let exe = Path::new(dir).join("conda");
+            if let Some(root) = root_of_exe(&exe) {
                 if has_conda_init(&root) {
                     return Some(root);
                 }
             }
         }
-
-        if let Ok(paths) = env::var("PATH") {
-            for dir in paths.split(path_sep) {
-                if dir.is_empty() {
-                    continue;
-                }
-                let exe = Path::new(dir).join("conda");
-                if let Some(root) = root_of_exe(&exe) {
-                    if has_conda_init(&root) {
-                        return Some(root);
-                    }
-                }
-            }
-        }
-
-        if let Ok(prefix) = env::var("CONDA_PREFIX") {
-            let mut candidate = PathBuf::from(prefix);
-            for _ in 0..3 {
-                if has_conda_init(&candidate) {
-                    return Some(candidate);
-                }
-                match candidate.parent() {
-                    Some(parent) => candidate = parent.to_path_buf(),
-                    None => break,
-                }
-            }
-        }
-
-        let mut candidates: Vec<PathBuf> = Vec::new();
-        if let Ok(home) = env::var("HOME") {
-            for name in [
-                "miniconda3",
-                "miniforge3",
-                "anaconda3",
-                "mambaforge",
-                "conda",
-            ] {
-                candidates.push(Path::new(&home).join(name));
-            }
-        }
-        for base in ["/opt", "/usr/local", "/usr/share"] {
-            for name in ["conda", "miniconda3", "miniforge3", "anaconda3"] {
-                candidates.push(Path::new(base).join(name));
-            }
-        }
-        candidates
-            .into_iter()
-            .find(|candidate| has_conda_init(candidate))
     }
 
+    if let Ok(prefix) = env::var("CONDA_PREFIX") {
+        let mut candidate = PathBuf::from(prefix);
+        for _ in 0..3 {
+            if has_conda_init(&candidate) {
+                return Some(candidate);
+            }
+            match candidate.parent() {
+                Some(parent) => candidate = parent.to_path_buf(),
+                None => break,
+            }
+        }
+    }
+
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Ok(home) = env::var("HOME") {
+        for name in [
+            "miniconda3",
+            "miniforge3",
+            "anaconda3",
+            "mambaforge",
+            "conda",
+        ] {
+            candidates.push(Path::new(&home).join(name));
+        }
+    }
+    for base in ["/opt", "/usr/local", "/usr/share"] {
+        for name in ["conda", "miniconda3", "miniforge3", "anaconda3"] {
+            candidates.push(Path::new(base).join(name));
+        }
+    }
+    candidates
+        .into_iter()
+        .find(|candidate| has_conda_init(candidate))
+}
+
+impl ProcessExecutor {
     /// Build the detached runner shell. The payload is executed by a nested
     /// bash so `exit` in user input cannot skip the result write performed by
     /// the outer runner.
@@ -352,7 +360,6 @@ impl ProcessExecutor {
         ))
     }
 }
-
 #[cfg(unix)]
 fn detach_with_setsid() -> Result<(), std::io::Error> {
     // SAFETY: setsid() is async-signal-safe and runs in the freshly forked
@@ -370,15 +377,30 @@ impl Executor for ProcessExecutor {
 
     fn execute(&self, job: &Job) -> Result<()> {
         let result_path = gflow::paths::get_runner_result_path(job.id)?;
-        let runner_command = Self::build_runner_command(job, &result_path)?;
-        Self::remove_runner_files(job.id);
 
+        // Prepare the log file before building the command so that a
+        // command-construction failure (e.g. a missing conda installation)
+        // still leaves an explanatory message in the job log.
         let log_path = gflow::paths::prepare_log_file_path(job.id)?;
         if let Some(parent) = log_path.parent() {
             fs::create_dir_all(parent)?;
         }
-        let log_file = fs::File::create(&log_path)
+        let mut log_file = fs::File::create(&log_path)
             .with_context(|| format!("Failed to create log file {}", log_path.display()))?;
+
+        let runner_command = match Self::build_runner_command(job, &result_path) {
+            Ok(command) => command,
+            Err(error) => {
+                let _ = writeln!(
+                    log_file,
+                    "gflow: failed to prepare job {} for execution: {error:#}",
+                    job.id
+                );
+                return Err(error);
+            }
+        };
+        Self::remove_runner_files(job.id);
+
         let stderr_file = log_file
             .try_clone()
             .context("Failed to clone log file handle")?;
@@ -676,7 +698,8 @@ impl Executor for TmuxExecutor {
             }
 
             if let Some(conda_env) = &job.conda_env {
-                session.try_send_command(&format!("conda activate {conda_env}"))?;
+                let activation = conda_activation_command(job, conda_env)?;
+                session.try_send_command(&activation)?;
             }
 
             let wrapped_command = self.generate_wrapped_command(job)?;
@@ -833,7 +856,7 @@ mod tests {
         let root = make_fake_conda_root(tempdir.path(), "");
         let found = with_conda_env_vars(
             &[("CONDA_EXE", Some(root.join("bin/conda").to_str().unwrap()))],
-            ProcessExecutor::locate_conda_root,
+            locate_conda_root,
         )
         .unwrap();
         assert_eq!(found, root);
@@ -849,7 +872,7 @@ mod tests {
                 ("CONDA_PREFIX", None),
                 ("PATH", Some(root.join("bin").to_str().unwrap())),
             ],
-            ProcessExecutor::locate_conda_root,
+            locate_conda_root,
         )
         .unwrap();
         assert_eq!(found, root);
@@ -869,7 +892,51 @@ mod tests {
                 ("CONDA_PREFIX", Some(env_dir.to_str().unwrap())),
                 ("PATH", Some("/nonexistent-for-test")),
             ],
-            ProcessExecutor::locate_conda_root,
+            locate_conda_root,
+        )
+        .unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[test]
+    fn test_conda_root_located_from_condabin_on_path() {
+        // Standard conda installs also expose `<root>/condabin/conda` (the
+        // shell shim), which `conda init` puts on PATH alongside `bin`.
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = tempdir.path().join("fakeroot");
+        fs::create_dir_all(root.join("condabin")).unwrap();
+        fs::create_dir_all(root.join("etc/profile.d")).unwrap();
+        fs::write(root.join("condabin/conda"), "#!bin/sh\n").unwrap();
+        fs::write(root.join("etc/profile.d/conda.sh"), "# fake\n").unwrap();
+        let found = with_conda_env_vars(
+            &[
+                ("CONDA_EXE", None),
+                ("CONDA_PREFIX", None),
+                ("PATH", Some(root.join("condabin").to_str().unwrap())),
+            ],
+            locate_conda_root,
+        )
+        .unwrap();
+        assert_eq!(found, root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_conda_root_located_through_symlink() {
+        // A `conda` symlink outside the installation (e.g. /usr/bin/conda)
+        // must resolve back to the real root.
+        let tempdir = tempfile::tempdir().unwrap();
+        let root = make_fake_conda_root(tempdir.path(), "");
+        let link_dir = tempdir.path().join("links");
+        fs::create_dir_all(&link_dir).unwrap();
+        std::os::unix::fs::symlink(root.join("bin/conda"), link_dir.join("conda")).unwrap();
+        let found = with_conda_env_vars(
+            &[
+                ("CONDA_EXE", None),
+                ("CONDA_PREFIX", None),
+                ("PATH", Some(link_dir.to_str().unwrap())),
+            ],
+            locate_conda_root,
         )
         .unwrap();
         assert_eq!(found, root);
@@ -1172,6 +1239,34 @@ conda() {
 
             assert_eq!(result.exit_code, Some(0));
             assert!(result.succeeded());
+        })
+    }
+
+    #[test]
+    fn test_process_executor_build_failure_is_written_to_job_log() {
+        // A command-construction failure (here: job with neither script nor
+        // command) must leave an explanatory message in the job log, not just
+        // the daemon log.
+        with_isolated_data_dir(|| {
+            let executor = ProcessExecutor::new();
+            let job = Job {
+                id: 9202,
+                state: JobState::Queued,
+                run_dir: PathBuf::from("/tmp"),
+                ..Default::default()
+            };
+            let error = executor.execute(&job).unwrap_err();
+
+            let log =
+                std::fs::read_to_string(gflow::paths::get_log_file_path(9202).unwrap()).unwrap();
+            assert!(
+                log.contains("failed to prepare job 9202"),
+                "job log should carry the failure reason, got: {log}"
+            );
+            assert!(log.contains("neither a script nor a command"), "log: {log}");
+            assert!(error.to_string().contains("neither a script nor a command"));
+
+            executor.cleanup(&job);
         })
     }
 }

--- a/src/multicall/gflowd/executor.rs
+++ b/src/multicall/gflowd/executor.rs
@@ -269,6 +269,13 @@ fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
         root.join("etc/profile.d/conda.sh").is_file()
     }
 
+    /// Validate a candidate root and return it canonicalized, so callers can
+    /// rely on a canonical path (matters on macOS, where `/var` is a symlink
+    /// to `/private/var`).
+    fn accept(root: &Path) -> Option<PathBuf> {
+        has_conda_init(root).then(|| fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf()))
+    }
+
     /// Derive the installation root from a path to a `conda` executable.
     /// Standard layouts put the entry point in `<root>/bin` (Python script)
     /// or `<root>/condabin` (shell shim); symlinks are resolved first so a
@@ -285,7 +292,7 @@ fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
 
     if let Ok(exe) = env::var("CONDA_EXE") {
         if let Some(root) = root_of_exe(Path::new(&exe)) {
-            if has_conda_init(&root) {
+            if let Some(root) = accept(&root) {
                 return Some(root);
             }
         }
@@ -298,7 +305,7 @@ fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
             }
             let exe = Path::new(dir).join("conda");
             if let Some(root) = root_of_exe(&exe) {
-                if has_conda_init(&root) {
+                if let Some(root) = accept(&root) {
                     return Some(root);
                 }
             }
@@ -308,8 +315,8 @@ fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
     if let Ok(prefix) = env::var("CONDA_PREFIX") {
         let mut candidate = PathBuf::from(prefix);
         for _ in 0..3 {
-            if has_conda_init(&candidate) {
-                return Some(candidate);
+            if let Some(root) = accept(&candidate) {
+                return Some(root);
             }
             match candidate.parent() {
                 Some(parent) => candidate = parent.to_path_buf(),
@@ -335,9 +342,7 @@ fn locate_conda_root_impl(path_sep: &str) -> Option<PathBuf> {
             candidates.push(Path::new(base).join(name));
         }
     }
-    candidates
-        .into_iter()
-        .find(|candidate| has_conda_init(candidate))
+    candidates.iter().find_map(|candidate| accept(candidate))
 }
 
 impl ProcessExecutor {
@@ -847,7 +852,9 @@ mod tests {
             format!("# fake conda init\n{init_extra}\n"),
         )
         .unwrap();
-        root
+        // Canonicalize so expectations match the canonicalized root returned
+        // by locate_conda_root (macOS: /var -> /private/var).
+        fs::canonicalize(&root).unwrap_or(root)
     }
 
     #[test]


### PR DESCRIPTION
Fixes the process executor failing to apply `--conda-env` jobs (W-439).

## Root cause

The process executor runs each job in a non-interactive, non-login
`bash -c` spawned by the daemon, so conda's shell init (from user rc
files) never ran. `conda activate` is a shell function installed by
conda's init, so every job with a conda env failed:

- `conda: command not found` (exit 127) when the daemon PATH lacks conda
  (e.g. daemon started by systemd),
- `CondaError: Run 'conda init' before 'conda activate'` (exit 1) when the
  daemon PATH does include conda's bin.

Both reproduced before the fix with a clean daemon-like environment.

## Changes

- `src/multicall/gflowd/executor.rs`:
  - `ProcessExecutor::locate_conda_root()` finds a conda installation at
    execution time: daemon `$CONDA_EXE` → `conda` on `$PATH` →
    `$CONDA_PREFIX` (and parents, for nested envs) → common locations
    (`~/miniconda3`, `~/anaconda3`, `/opt/conda`, `/usr/local/...`, ...).
  - The runner now sources `<root>/etc/profile.d/conda.sh` before
    `conda activate <env>`; if no installation is found the job fails
    fast with an explanatory error instead of dying mid-run.
  - The conda env name and script path are shell-quoted (previously
    unquoted — spaces/metas in env names or script paths broke or
    injected into the runner command). Same quoting fix applied to the
    tmux executor's script path.
- Docs (`user-guide/configuration.md` + zh-CN) and CHANGELOG updated.
- Tests: conda root location (CONDA_EXE / PATH / CONDA_PREFIX), command
  building (init sourced before activate, env-name quoting, script path
  quoting), and a live end-to-end test running a fake conda init through
  the real runner.

## Verification

- `cargo test --locked --all-features --workspace` — all pass
- `cargo clippy --all-targets --all-features` — clean
- `cargo fmt --all --check` — clean
- Manual e2e: daemon started with `env -i PATH=/usr/bin:/bin` (no conda
  anywhere) + `gbatch -c ljm python -c '...'` → job log shows
  `CONDA_DEFAULT_ENV= ljm`, `python= /home/.../envs/ljm/bin/python`