### PR TITLE
docs: restyle runqd.com landing page with cohesive blue theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,13 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log button.
 
 ### Changed
-- **docs: restyle the landing page (runqd.com) with a cohesive blue theme**:
-  the homepage palette now matches the `gflow` logo (blue/indigo on a clean
-  light/dark neutral) replacing the old cream/orange, and the intended
-  Space Grotesk display and IBM Plex Mono code fonts are loaded and applied
-  to headings and commands. Layout is tightened with section spacing, card
-  hover states, gradient accent eyebrows/stat values, and a 3-column
-  capabilities grid so both locales and mobile stay balanced.
+- **docs: restyle the landing page (runqd.com) into a minimal, flat look**:
+  the homepage now uses a neutral light/dark surface with a single restrained
+  blue accent and thin 1px borders — no gradients, glassmorphism, glows, or
+  animation — so it reads as a serious scheduler/infra tool rather than a
+  marketing page. The intended Space Grotesk display and IBM Plex Mono code
+  fonts are loaded and applied to headings and commands; the hero is
+  simplified to headline + a clean terminal (the floating cards are removed),
+  and the capabilities grid uses 3 columns. Balanced across both locales and
+  mobile.
 - **web: jobs table shows runtime instead of "Starts at"**: the almost-empty
   scheduled-time column is replaced by a `Runtime` column — elapsed time for
   running jobs (grows with refreshes) and total runtime for finished ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log button.
 
 ### Changed
+- **docs: restyle the landing page (runqd.com) with a cohesive blue theme**:
+  the homepage palette now matches the `gflow` logo (blue/indigo on a clean
+  light/dark neutral) replacing the old cream/orange, and the intended
+  Space Grotesk display and IBM Plex Mono code fonts are loaded and applied
+  to headings and commands. Layout is tightened with section spacing, card
+  hover states, gradient accent eyebrows/stat values, and a 3-column
+  capabilities grid so both locales and mobile stay balanced.
 - **web: jobs table shows runtime instead of "Starts at"**: the almost-empty
   scheduled-time column is replaced by a `Runtime` column — elapsed time for
   running jobs (grows with refreshes) and total runtime for finished ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   industrial style**: the homepage is a flat, grid-driven layout built only
   from 1px hairlines — no rounded cards, shadows, gradients, or decorative
   elements — in pure white / deep charcoal with a single IBM Blue `#0f62fe`
-  accent. Typography moves to IBM Plex Sans (display + body) and IBM Plex Mono
-  (labels, code, specs), with a large bold grotesque hero, numbered section
-  rows (01–05), a flat borderless terminal, a dark MCP band, and a solid IBM
-  Blue closing band. Verified flat and clean in light, dark, zh-CN, and mobile
-  via headless screenshots.
+  accent, set in IBM Plex Sans + IBM Plex Mono. The hero is a large bold
+  statement; the terminal now **plays out a live session** (commands stream
+  in, the job flips PENDING → RUNNING, blinking cursor, pulsing status dot,
+  loops, and respects `prefers-reduced-motion`), and “How it works” is an
+  animated pipeline with a sequential sweep. Copy was trimmed to be punchier
+  and less text-heavy. Verified in light, dark, zh-CN, and mobile.
 - **web: jobs table shows runtime instead of "Starts at"**: the almost-empty
   scheduled-time column is replaced by a `Runtime` column — elapsed time for
   running jobs (grows with refreshes) and total runtime for finished ones.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,15 +17,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   log button.
 
 ### Changed
-- **docs: restyle the landing page (runqd.com) into a minimal, flat look**:
-  the homepage now uses a neutral light/dark surface with a single restrained
-  blue accent and thin 1px borders — no gradients, glassmorphism, glows, or
-  animation — so it reads as a serious scheduler/infra tool rather than a
-  marketing page. The intended Space Grotesk display and IBM Plex Mono code
-  fonts are loaded and applied to headings and commands; the hero is
-  simplified to headline + a clean terminal (the floating cards are removed),
-  and the capabilities grid uses 3 columns. Balanced across both locales and
-  mobile.
+- **docs: restyle the landing page (runqd.com) into an IBM Carbon / Swiss
+  industrial style**: the homepage is a flat, grid-driven layout built only
+  from 1px hairlines — no rounded cards, shadows, gradients, or decorative
+  elements — in pure white / deep charcoal with a single IBM Blue `#0f62fe`
+  accent. Typography moves to IBM Plex Sans (display + body) and IBM Plex Mono
+  (labels, code, specs), with a large bold grotesque hero, numbered section
+  rows (01–05), a flat borderless terminal, a dark MCP band, and a solid IBM
+  Blue closing band. Verified flat and clean in light, dark, zh-CN, and mobile
+  via headless screenshots.
 - **web: jobs table shows runtime instead of "Starts at"**: the almost-empty
   scheduled-time column is replaced by a `Runtime` column — elapsed time for
   running jobs (grows with refreshes) and total runtime for finished ones.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
             "link",
             {
                 rel: "stylesheet",
-                href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap",
+                href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap",
             },
         ],
     ],

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -10,6 +10,18 @@ export default defineConfig({
     head: [
         ["link", { rel: "icon", type: "image/svg+xml", href: "/favicon.svg" }],
         ["link", { rel: "shortcut icon", href: "/favicon.svg" }],
+        ["link", { rel: "preconnect", href: "https://fonts.googleapis.com" }],
+        [
+            "link",
+            { rel: "preconnect", href: "https://fonts.gstatic.com", crossorigin: "" },
+        ],
+        [
+            "link",
+            {
+                rel: "stylesheet",
+                href: "https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=Space+Grotesk:wght@400;500;600;700&display=swap",
+            },
+        ],
     ],
 
     locales: {

--- a/docs/.vitepress/theme/components/LandingPage.vue
+++ b/docs/.vitepress/theme/components/LandingPage.vue
@@ -267,13 +267,13 @@ const copies = {
                 },
                 {
                     title: "Jump to command reference",
-                    body: "Use the cheat sheet for `gflowd`, `gbatch`, `gqueue`, `gjob`, `gctl`, and more.",
+                    body: "Use the cheat sheet for gflowd, gbatch, gqueue, gjob, gctl, and more.",
                     href: "/reference/quick-reference",
                     cta: "Open Reference",
                 },
                 {
                     title: "Connect your agents",
-                    body: "Run `gflow` as a local MCP server for agent tooling.",
+                    body: "Run gflow as a local MCP server for agent tooling.",
                     href: "/ai-integration/mcp-and-skills",
                     cta: "Open AI Integration",
                 },
@@ -468,7 +468,7 @@ const copies = {
                 },
                 {
                     title: "连接你的 Agent",
-                    body: "把 `gflow` 作为本地 MCP server 接给 Agent 工具。",
+                    body: "把 gflow 作为本地 MCP server 接给 Agent 工具。",
                     href: "/zh-CN/ai-integration/mcp-and-skills",
                     cta: "查看 AI 集成",
                 },
@@ -503,53 +503,49 @@ const workflowSteps = computed(() =>
     })),
 );
 const mcpCommandHtml = computed(() => highlightShell(copy.value.mcp.command));
+
+function pad(n: number) {
+    return String(n).padStart(2, "0");
+}
 </script>
 
 <template>
     <div class="landing-page">
-        <section class="lp-hero">
-            <div class="lp-hero-copy">
-                <div class="lp-brand">
-                    <img alt="gflow" class="lp-brand-logo" src="/logo.svg" />
-                    <span>gflow</span>
-                </div>
-                <p class="lp-eyebrow">{{ copy.hero.eyebrow }}</p>
-                <h1 class="lp-title">{{ copy.hero.title }}</h1>
-                <p class="lp-lead">{{ copy.hero.lead }}</p>
-                <div class="lp-actions">
-                    <a
-                        v-for="action in copy.hero.actions"
-                        :key="action.href"
-                        :class="['lp-button', `lp-button-${action.kind}`]"
-                        :href="action.href"
-                    >
-                        {{ action.label }}
-                    </a>
-                </div>
-                <ul class="lp-trust">
-                    <li v-for="item in copy.hero.trust" :key="item">{{ item }}</li>
-                </ul>
-                <div class="lp-stats">
-                    <article v-for="item in copy.hero.stats" :key="item.value" class="lp-stat-card">
-                        <p class="lp-stat-value">{{ item.value }}</p>
-                        <p class="lp-stat-label">{{ item.label }}</p>
-                    </article>
+        <!-- HERO -->
+        <header class="lp-hero">
+            <div class="lp-container">
+                <p class="lp-label"><span class="lp-label-tick" aria-hidden="true"></span>{{ copy.hero.eyebrow }}</p>
+                <h1 class="lp-hero-title">{{ copy.hero.title }}</h1>
+                <p class="lp-hero-lead">{{ copy.hero.lead }}</p>
+                <div class="lp-hero-actions">
+                    <a class="lp-btn lp-btn-primary" :href="copy.hero.actions[0].href">{{ copy.hero.actions[0].label }}</a>
+                    <a class="lp-btn-text" :href="copy.hero.actions[1].href">{{ copy.hero.actions[1].label }}<span class="lp-arrow" aria-hidden="true">→</span></a>
+                    <a class="lp-btn-text" :href="copy.hero.actions[2].href">{{ copy.hero.actions[2].label }}<span class="lp-arrow" aria-hidden="true">→</span></a>
                 </div>
             </div>
+            <div class="lp-container">
+                <ul class="lp-specstrip">
+                    <li v-for="(item, i) in copy.hero.trust" :key="item" class="lp-spec">
+                        <span class="lp-spec-idx" aria-hidden="true">{{ pad(i + 1) }}</span>
+                        <span class="lp-spec-text">{{ item }}</span>
+                    </li>
+                </ul>
+            </div>
+        </header>
 
-            <div class="lp-hero-visual">
+        <!-- TERMINAL -->
+        <section class="lp-section">
+            <div class="lp-container">
                 <div class="lp-terminal">
-                    <div class="lp-terminal-bar">
-                        <span />
-                        <span />
-                        <span />
-                        <strong>{{ copy.panel.title }}</strong>
+                    <div class="lp-terminal-head">
+                        <span class="lp-terminal-path">{{ copy.panel.title }}</span>
+                        <span class="lp-terminal-meta">gflowd&nbsp;·&nbsp;127.0.0.1:5577</span>
                     </div>
                     <div class="lp-terminal-body">
                         <div
                             v-for="(line, index) in terminalLines"
-                            :key="`${currentLocale}-${index}`"
-                            :class="['lp-terminal-line', `lp-terminal-line-${line.kind}`]"
+                            :key="index"
+                            :class="['lp-tl', `lp-tl-${line.kind}`]"
                             v-html="line.html"
                         />
                     </div>
@@ -557,106 +553,121 @@ const mcpCommandHtml = computed(() => highlightShell(copy.value.mcp.command));
             </div>
         </section>
 
+        <!-- 01 · WHY -->
         <section class="lp-section">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.problem.eyebrow }}</p>
-                <h2>{{ copy.problem.title }}</h2>
-                <p>{{ copy.problem.lead }}</p>
-            </div>
-            <div class="lp-compare">
-                <article class="lp-compare-card">
-                    <p class="lp-compare-label">{{ copy.problem.painTitle }}</p>
-                    <ul>
-                        <li v-for="item in copy.problem.painItems" :key="item">{{ item }}</li>
-                    </ul>
-                </article>
-                <article class="lp-compare-card lp-compare-card-accent">
-                    <p class="lp-compare-label">{{ copy.problem.valueTitle }}</p>
-                    <ul>
-                        <li v-for="item in copy.problem.valueItems" :key="item">{{ item }}</li>
-                    </ul>
-                </article>
+            <div class="lp-container">
+                <div class="lp-sec-head">
+                    <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(1) }}</span>{{ copy.problem.eyebrow }}</p>
+                    <h2 class="lp-sec-title">{{ copy.problem.title }}</h2>
+                    <p class="lp-sec-lead">{{ copy.problem.lead }}</p>
+                </div>
+                <div class="lp-grid lp-grid-2">
+                    <div class="lp-cell">
+                        <p class="lp-cell-label lp-cell-label-dim">{{ copy.problem.painTitle }}</p>
+                        <ul class="lp-list lp-list-minus">
+                            <li v-for="item in copy.problem.painItems" :key="item">{{ item }}</li>
+                        </ul>
+                    </div>
+                    <div class="lp-cell">
+                        <p class="lp-cell-label lp-cell-label-accent">{{ copy.problem.valueTitle }}</p>
+                        <ul class="lp-list lp-list-plus">
+                            <li v-for="item in copy.problem.valueItems" :key="item">{{ item }}</li>
+                        </ul>
+                    </div>
+                </div>
             </div>
         </section>
 
+        <!-- 02 · HOW IT WORKS -->
         <section class="lp-section">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.workflow.eyebrow }}</p>
-                <h2>{{ copy.workflow.title }}</h2>
-            </div>
-            <div class="lp-step-grid">
-                <article v-for="step in workflowSteps" :key="step.label" class="lp-step-card">
-                    <span class="lp-step-label">{{ step.label }}</span>
-                    <code class="lp-code-inline" v-html="step.commandHtml"></code>
-                    <p>{{ step.description }}</p>
-                </article>
+            <div class="lp-container">
+                <div class="lp-sec-head">
+                    <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(2) }}</span>{{ copy.workflow.eyebrow }}</p>
+                    <h2 class="lp-sec-title">{{ copy.workflow.title }}</h2>
+                </div>
+                <div class="lp-grid lp-grid-4">
+                    <div class="lp-cell lp-step" v-for="step in workflowSteps" :key="step.label">
+                        <code class="lp-step-cmd" v-html="step.commandHtml"></code>
+                        <p class="lp-step-desc">{{ step.description }}</p>
+                    </div>
+                </div>
             </div>
         </section>
 
+        <!-- 03 · CAPABILITIES -->
         <section class="lp-section">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.capabilities.eyebrow }}</p>
-                <h2>{{ copy.capabilities.title }}</h2>
-            </div>
-            <div class="lp-card-grid lp-card-grid-caps">
-                <article v-for="item in copy.capabilities.items" :key="item.title" class="lp-card">
-                    <h3>{{ item.title }}</h3>
-                    <p>{{ item.body }}</p>
-                </article>
+            <div class="lp-container">
+                <div class="lp-sec-head">
+                    <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(3) }}</span>{{ copy.capabilities.eyebrow }}</p>
+                    <h2 class="lp-sec-title">{{ copy.capabilities.title }}</h2>
+                </div>
+                <div class="lp-grid lp-grid-3">
+                    <div class="lp-cell" v-for="(item, i) in copy.capabilities.items" :key="item.title">
+                        <span class="lp-cell-idx" aria-hidden="true">{{ pad(i + 1) }}</span>
+                        <h3 class="lp-cell-title">{{ item.title }}</h3>
+                        <p class="lp-cell-body">{{ item.body }}</p>
+                    </div>
+                </div>
             </div>
         </section>
 
+        <!-- 04 · WHERE IT FITS -->
         <section class="lp-section">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.scenarios.eyebrow }}</p>
-                <h2>{{ copy.scenarios.title }}</h2>
-            </div>
-            <div class="lp-card-grid lp-card-grid-scenarios">
-                <article v-for="item in copy.scenarios.items" :key="item.title" class="lp-card lp-card-scenario">
-                    <h3>{{ item.title }}</h3>
-                    <p>{{ item.body }}</p>
-                </article>
+            <div class="lp-container">
+                <div class="lp-sec-head">
+                    <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(4) }}</span>{{ copy.scenarios.eyebrow }}</p>
+                    <h2 class="lp-sec-title">{{ copy.scenarios.title }}</h2>
+                </div>
+                <div class="lp-grid lp-grid-3">
+                    <div class="lp-cell" v-for="item in copy.scenarios.items" :key="item.title">
+                        <h3 class="lp-cell-title">{{ item.title }}</h3>
+                        <p class="lp-cell-body">{{ item.body }}</p>
+                    </div>
+                </div>
             </div>
         </section>
 
+        <!-- 05 · DOCUMENTATION -->
         <section class="lp-section">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.pathways.eyebrow }}</p>
-                <h2>{{ copy.pathways.title }}</h2>
-            </div>
-            <div class="lp-card-grid">
-                <article v-for="item in copy.pathways.items" :key="item.href" class="lp-card lp-card-link">
-                    <h3>{{ item.title }}</h3>
-                    <p>{{ item.body }}</p>
-                    <a :href="item.href">{{ item.cta }}</a>
-                </article>
-            </div>
-        </section>
-
-        <section class="lp-section lp-mcp-callout">
-            <div class="lp-section-heading">
-                <p class="lp-eyebrow">{{ copy.mcp.eyebrow }}</p>
-                <h2>{{ copy.mcp.title }}</h2>
-                <p>{{ copy.mcp.lead }}</p>
-            </div>
-            <div class="lp-mcp-row">
-                <pre><code class="lp-code-inline" v-html="mcpCommandHtml"></code></pre>
-                <a class="lp-button lp-button-brand" :href="copy.mcp.href">{{ copy.mcp.cta }}</a>
+            <div class="lp-container">
+                <div class="lp-sec-head">
+                    <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(5) }}</span>{{ copy.pathways.eyebrow }}</p>
+                    <h2 class="lp-sec-title">{{ copy.pathways.title }}</h2>
+                </div>
+                <div class="lp-table">
+                    <a class="lp-table-row" v-for="item in copy.pathways.items" :key="item.href" :href="item.href">
+                        <span class="lp-table-title">{{ item.title }}</span>
+                        <span class="lp-table-body">{{ item.body }}</span>
+                        <span class="lp-table-cta">{{ item.cta }}<span class="lp-arrow" aria-hidden="true">→</span></span>
+                    </a>
+                </div>
             </div>
         </section>
 
+        <!-- AI / MCP BAND -->
+        <section class="lp-band">
+            <div class="lp-container lp-band-inner">
+                <div class="lp-band-copy">
+                    <p class="lp-label lp-label-inv"><span class="lp-label-tick lp-label-tick-inv" aria-hidden="true"></span>{{ copy.mcp.eyebrow }}</p>
+                    <h2 class="lp-band-title">{{ copy.mcp.title }}</h2>
+                    <p class="lp-band-lead">{{ copy.mcp.lead }}</p>
+                </div>
+                <div class="lp-band-action">
+                    <pre class="lp-band-cmd"><code v-html="mcpCommandHtml"></code></pre>
+                    <a class="lp-btn lp-btn-inv" :href="copy.mcp.href">{{ copy.mcp.cta }}<span class="lp-arrow" aria-hidden="true">→</span></a>
+                </div>
+            </div>
+        </section>
+
+        <!-- CLOSING -->
         <section class="lp-closing">
-            <h2>{{ copy.cta.title }}</h2>
-            <p>{{ copy.cta.lead }}</p>
-            <div class="lp-actions">
-                <a
-                    v-for="action in copy.cta.actions"
-                    :key="action.href"
-                    :class="['lp-button', `lp-button-${action.kind}`]"
-                    :href="action.href"
-                >
-                    {{ action.label }}
-                </a>
+            <div class="lp-container">
+                <h2 class="lp-closing-title">{{ copy.cta.title }}</h2>
+                <p class="lp-closing-lead">{{ copy.cta.lead }}</p>
+                <div class="lp-hero-actions">
+                    <a class="lp-btn lp-btn-onblue" :href="copy.cta.actions[0].href">{{ copy.cta.actions[0].label }}</a>
+                    <a class="lp-btn-text lp-btn-text-inv" :href="copy.cta.actions[1].href">{{ copy.cta.actions[1].label }}<span class="lp-arrow" aria-hidden="true">→</span></a>
+                </div>
             </div>
         </section>
     </div>

--- a/docs/.vitepress/theme/components/LandingPage.vue
+++ b/docs/.vitepress/theme/components/LandingPage.vue
@@ -616,7 +616,7 @@ const mcpCommandHtml = computed(() => highlightShell(copy.value.mcp.command));
                 <p class="lp-eyebrow">{{ copy.capabilities.eyebrow }}</p>
                 <h2>{{ copy.capabilities.title }}</h2>
             </div>
-            <div class="lp-card-grid">
+            <div class="lp-card-grid lp-card-grid-caps">
                 <article v-for="item in copy.capabilities.items" :key="item.title" class="lp-card">
                     <h3>{{ item.title }}</h3>
                     <p>{{ item.body }}</p>

--- a/docs/.vitepress/theme/components/LandingPage.vue
+++ b/docs/.vitepress/theme/components/LandingPage.vue
@@ -554,24 +554,6 @@ const mcpCommandHtml = computed(() => highlightShell(copy.value.mcp.command));
                         />
                     </div>
                 </div>
-                <article class="lp-floating-card lp-floating-card-queue">
-                    <p class="lp-floating-title">{{ copy.panel.queueCardTitle }}</p>
-                    <div class="lp-floating-grid">
-                        <div v-for="item in copy.panel.queueCardValues" :key="item.label">
-                            <span>{{ item.label }}</span>
-                            <strong>{{ item.value }}</strong>
-                        </div>
-                    </div>
-                </article>
-                <article class="lp-floating-card lp-floating-card-gpu">
-                    <p class="lp-floating-title">{{ copy.panel.gpuCardTitle }}</p>
-                    <div class="lp-floating-stack">
-                        <div v-for="item in copy.panel.gpuCardValues" :key="item.label">
-                            <span>{{ item.label }}</span>
-                            <strong>{{ item.value }}</strong>
-                        </div>
-                    </div>
-                </article>
             </div>
         </section>
 

--- a/docs/.vitepress/theme/components/LandingPage.vue
+++ b/docs/.vitepress/theme/components/LandingPage.vue
@@ -1,115 +1,79 @@
 <script setup lang="ts">
-import { computed } from "vue";
-import { createHighlighterCoreSync } from "@shikijs/core";
-import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
-import bash from "@shikijs/langs/bash";
-import githubDark from "@shikijs/themes/github-dark";
-import githubLight from "@shikijs/themes/github-light";
+import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 
 const props = defineProps<{
     locale?: "en" | "zh-CN";
 }>();
 
-const highlighter = createHighlighterCoreSync({
-    engine: createJavaScriptRegexEngine(),
-    themes: [githubLight, githubDark],
-    langs: [bash],
+/*
+ * The terminal session is a fixed, bilingual-agnostic CLI demo. Each row
+ * reveals on its own frame; the job row flips PENDING -> RUNNING; a block
+ * cursor sits on the most recent command. The whole thing loops.
+ */
+type TermRow = {
+    kind: "cmd" | "ok" | "thead" | "trow" | "metric";
+    at: number;
+    text?: string;
+    cells?: string[];
+    id?: string;
+    name?: string;
+    gpu?: string;
+    node?: string;
+};
+
+const TERMINAL: TermRow[] = [
+    { kind: "cmd", text: "gflowd up", at: 1 },
+    { kind: "ok", text: "daemon ready on 127.0.0.1:5577", at: 2 },
+    { kind: "cmd", text: "gbatch --gpus 1 --project vision python train.py", at: 3 },
+    { kind: "ok", text: "submitted batch job 184", at: 4 },
+    { kind: "cmd", text: "gqueue", at: 5 },
+    { kind: "thead", cells: ["JOBID", "NAME", "STATE", "GPU", "NODE"], at: 6 },
+    { kind: "trow", id: "184", name: "train", gpu: "1", node: "e40a", at: 6 },
+    { kind: "cmd", text: "gjob log 184", at: 8 },
+    { kind: "metric", text: "step=420  loss=0.184  throughput=178 img/s", at: 9 },
+];
+
+const MAX_FRAME = 9;
+const HOLD = 4;
+const BEAT_MS = 780;
+const JOB_RUNS_AT = 8;
+
+const frame = ref(MAX_FRAME);
+let timer: number | undefined;
+
+onMounted(() => {
+    const reduce =
+        typeof window !== "undefined" &&
+        window.matchMedia?.("(prefers-reduced-motion: reduce)").matches;
+    if (reduce) return;
+    timer = window.setInterval(() => {
+        frame.value += 1;
+        if (frame.value > MAX_FRAME + HOLD) frame.value = 1;
+    }, BEAT_MS);
 });
 
-const highlightThemes = {
-    light: "github-light",
-    dark: "github-dark",
-} as const;
+onBeforeUnmount(() => {
+    if (timer !== undefined) window.clearInterval(timer);
+});
 
-function escapeHtml(value: string) {
-    return value
-        .replaceAll("&", "&amp;")
-        .replaceAll("<", "&lt;")
-        .replaceAll(">", "&gt;")
-        .replaceAll('"', "&quot;")
-        .replaceAll("'", "&#39;");
-}
-
-function extractCodeHtml(html: string) {
-    const match = html.match(/<code[^>]*>([\s\S]*?)<\/code>/);
-    return match?.[1] ?? html;
-}
-
-function highlightShell(code: string) {
-    let placeholderIndex = 0;
-    const placeholders = new Map<string, string>();
-    const normalizedCode = code.replace(/<[^>\n]+>/g, (placeholder) => {
-        const token = `GFLOWPLACEHOLDER${placeholderIndex++}`;
-        placeholders.set(token, placeholder);
-        return token;
+const activeCmd = computed(() => {
+    let idx = -1;
+    TERMINAL.forEach((row, i) => {
+        if (row.kind === "cmd" && row.at <= frame.value) idx = i;
     });
-
-    let html = extractCodeHtml(
-        highlighter.codeToHtml(normalizedCode, {
-            lang: "bash",
-            themes: highlightThemes,
-        }),
-    );
-
-    for (const [token, placeholder] of placeholders) {
-        html = html.replace(token, `<span class="lp-code-placeholder">${escapeHtml(placeholder)}</span>`);
-    }
-
-    return html;
-}
-
-function classifyTerminalLine(line: string) {
-    if (line.startsWith("$ ")) {
-        return {
-            kind: "command",
-            html: `<span class="lp-terminal-prompt">$</span> ${highlightShell(line.slice(2))}`,
-        };
-    }
-
-    if (line.startsWith("JOBID")) {
-        return {
-            kind: "header",
-            html: escapeHtml(line),
-        };
-    }
-
-    if (/^\d+\s+/.test(line)) {
-        return {
-            kind: "table",
-            html: escapeHtml(line),
-        };
-    }
-
-    if (line.includes("=")) {
-        return {
-            kind: "metrics",
-            html: escapeHtml(line),
-        };
-    }
-
-    if (line.startsWith("daemon ready") || line.startsWith("submitted batch job")) {
-        return {
-            kind: "success",
-            html: escapeHtml(line),
-        };
-    }
-
-    return {
-        kind: "output",
-        html: escapeHtml(line),
-    };
-}
+    return idx;
+});
 
 const copies = {
     en: {
         hero: {
             eyebrow: "Single-node scheduling for shared machines",
             title: "Give one Linux machine a real job scheduler",
-            lead: "Queue, run, and inspect GPU or CPU jobs on a shared workstation with a small CLI and a local daemon.",
+            lead: "A small CLI and a local daemon to submit, schedule, and inspect GPU or CPU jobs.",
             actions: [
-                { label: "Quick Start", href: "/getting-started/quick-start", kind: "brand" },
-                { label: "Installation", href: "/getting-started/installation", kind: "alt" },
-                { label: "Command Reference", href: "/reference/quick-reference", kind: "ghost" },
+                { label: "Quick Start", href: "/getting-started/quick-start" },
+                { label: "Installation", href: "/getting-started/installation" },
+                { label: "Command Reference", href: "/reference/quick-reference" },
             ],
             trust: [
                 "Single-node by design",
@@ -117,182 +81,80 @@ const copies = {
                 "tmux-backed execution",
                 "MCP-ready for agents",
             ],
-            stats: [
-                {
-                    value: "CLI-first",
-                    label: "Queueing, control, and inspection from familiar commands.",
-                },
-                {
-                    value: "Recoverable",
-                    label: "Attach, follow logs, and redo failed work.",
-                },
-                {
-                    value: "Explicit policy",
-                    label: "Declare GPUs, VRAM limits, priorities, reservations, and dependencies.",
-                },
-            ],
         },
-        panel: {
-            title: "Workstation session",
-            lines: [
-                "$ gflowd up",
-                "daemon ready on 127.0.0.1:5577",
-                "$ gbatch --gpus 1 --project vision python train.py",
-                "submitted batch job 184",
-                "$ gqueue",
-                "JOBID  NAME    ST  TIME      GPU  NODELIST(REASON)",
-                "184    train   R   00:12:41  1    0",
-                "185    eval    PD  -         0    (WaitingForDependency)",
-                "$ gjob log 184",
-                "step=420 loss=0.184 throughput=178 img/s",
-            ],
-            queueCardTitle: "Queue snapshot",
-            queueCardValues: [
-                { label: "Running", value: "04" },
-                { label: "Queued", value: "09" },
-                { label: "Held", value: "01" },
-            ],
-            gpuCardTitle: "GPU policy",
-            gpuCardValues: [
-                { label: "Visible", value: "0,1,2,3" },
-                { label: "Shared", value: "VRAM-aware" },
-            ],
-        },
+        panel: { title: "Workstation session" },
         problem: {
             eyebrow: "Why it exists",
             title: "When one machine is no longer just yours",
-            lead: "Ad hoc tmux sessions and manual GPU etiquette break down once a workstation is shared.",
-            painTitle: "Without queue discipline",
+            lead: "Ad-hoc tmux and GPU etiquette fall apart once the box is shared.",
+            painTitle: "Without discipline",
             painItems: [
                 "Long jobs collide with interactive work.",
-                "Failures are hard to recover because state and logs are scattered.",
-                "GPU requests become tribal knowledge instead of policy.",
+                "Failures scatter across logs with no state to recover.",
+                "GPU rules live in tribal knowledge, not policy.",
             ],
             valueTitle: "With gflow",
             valueItems: [
-                "A local daemon keeps state and queue control consistent.",
-                "Every job has a lifecycle you can inspect and recover.",
-                "Resources and dependencies are declared at submission time.",
+                "One daemon owns state and the queue.",
+                "Every job is inspectable and recoverable.",
+                "Resources and dependencies are declared up front.",
             ],
         },
         workflow: {
             eyebrow: "How it works",
-            title: "A familiar flow in four commands",
+            title: "Four commands, one controlled run",
             steps: [
-                {
-                    label: "01",
-                    command: "gflowd up",
-                    description: "Start the local scheduler.",
-                },
-                {
-                    label: "02",
-                    command: "gbatch --gpus 1 python train.py",
-                    description: "Submit a command or script with explicit resources.",
-                },
-                {
-                    label: "03",
-                    command: "gqueue",
-                    description: "Inspect running, queued, or completed jobs.",
-                },
-                {
-                    label: "04",
-                    command: "gjob log <job_id>",
-                    description: "Follow logs or attach when a run needs attention.",
-                },
+                { idx: "01", cmd: "gflowd up", label: "Start the daemon" },
+                { idx: "02", cmd: "gbatch --gpus 1", label: "Submit a job" },
+                { idx: "03", cmd: "gqueue", label: "Watch it schedule" },
+                { idx: "04", cmd: "gjob log <id>", label: "Follow the run" },
             ],
         },
         capabilities: {
             eyebrow: "Capabilities",
             title: "Built for daily workstation use",
             items: [
-                {
-                    title: "Queueing and lifecycle",
-                    body: "Submit, hold, release, cancel, update, and redo jobs with an inspectable state model.",
-                },
-                {
-                    title: "GPU-aware scheduling",
-                    body: "Request GPUs directly, enable shared mode, and set VRAM limits.",
-                },
-                {
-                    title: "Workflow composition",
-                    body: "Use dependencies, arrays, and parameter sweeps for multi-stage runs.",
-                },
-                {
-                    title: "Operational visibility",
-                    body: "Read queue state through tables, trees, JSON, CSV, or YAML.",
-                },
-                {
-                    title: "Recoverable execution",
-                    body: "Run each job in its own tmux session for direct logs and recovery.",
-                },
-                {
-                    title: "Automation and AI integration",
-                    body: "Expose scheduler actions through a local MCP server.",
-                },
+                { title: "Queueing & lifecycle", body: "Submit, hold, cancel, update, and redo jobs." },
+                { title: "GPU-aware scheduling", body: "Request GPUs, share them, and cap VRAM." },
+                { title: "Workflow composition", body: "Chain dependencies, arrays, and sweeps." },
+                { title: "Operational visibility", body: "Read state as table, tree, JSON, CSV, or YAML." },
+                { title: "Recoverable execution", body: "Every job runs in its own tmux session." },
+                { title: "Automation & AI", body: "Drive the scheduler through a local MCP server." },
             ],
         },
         scenarios: {
             eyebrow: "Where it fits",
-            title: "Common scenarios",
+            title: "Where it fits",
             items: [
-                {
-                    title: "Shared lab GPU server",
-                    body: "Coordinate multiple researchers on one box with explicit scheduling rules.",
-                },
-                {
-                    title: "Solo research machine",
-                    body: "Keep long-running experiments structured and restartable.",
-                },
-                {
-                    title: "Local evaluation pipelines",
-                    body: "Chain prep, train, benchmark, and reporting jobs with dependencies.",
-                },
+                { title: "Shared lab GPU server", body: "Coordinate many researchers on one box." },
+                { title: "Solo research machine", body: "Keep long experiments structured and restartable." },
+                { title: "Local eval pipelines", body: "Chain prep, train, benchmark, and report." },
             ],
         },
         pathways: {
-            eyebrow: "Documentation paths",
+            eyebrow: "Documentation",
             title: "Start where you are",
             items: [
-                {
-                    title: "Install and launch",
-                    body: "Install the binary, create config defaults, and start the daemon.",
-                    href: "/getting-started/installation",
-                    cta: "Open Installation",
-                },
-                {
-                    title: "Learn the first workflow",
-                    body: "Start the daemon, submit a job, inspect the queue, and read logs.",
-                    href: "/getting-started/quick-start",
-                    cta: "Open Quick Start",
-                },
-                {
-                    title: "Jump to command reference",
-                    body: "Use the cheat sheet for gflowd, gbatch, gqueue, gjob, gctl, and more.",
-                    href: "/reference/quick-reference",
-                    cta: "Open Reference",
-                },
-                {
-                    title: "Connect your agents",
-                    body: "Run gflow as a local MCP server for agent tooling.",
-                    href: "/ai-integration/mcp-and-skills",
-                    cta: "Open AI Integration",
-                },
+                { title: "Install and launch", body: "Install, configure, and start the daemon.", href: "/getting-started/installation", cta: "Installation" },
+                { title: "First workflow", body: "Submit a job, inspect the queue, read logs.", href: "/getting-started/quick-start", cta: "Quick Start" },
+                { title: "Command reference", body: "Cheat sheet for gflowd, gbatch, gqueue, gjob, gctl.", href: "/reference/quick-reference", cta: "Reference" },
+                { title: "Connect agents", body: "Run gflow as a local MCP server.", href: "/ai-integration/mcp-and-skills", cta: "AI Integration" },
             ],
         },
         mcp: {
             eyebrow: "AI integration",
-            title: "Make scheduler operations available as tools",
-            lead: "Run gflow as a local stdio MCP server so agent CLIs can inspect queues and drive scheduler workflows.",
+            title: "Turn scheduler operations into agent tools",
+            lead: "Run gflow as a local stdio MCP server; agent CLIs can inspect queues and drive workflows.",
             command: "gflow mcp serve",
             href: "/ai-integration/mcp-and-skills",
-            cta: "Read Agents, MCP, and Skills",
+            cta: "Read the AI guide",
         },
         cta: {
             title: "Start scheduling the machine you already have",
-            lead: "Use the docs as an operator handbook.",
+            lead: "The docs double as an operator's handbook.",
             actions: [
-                { label: "Install gflow", href: "/getting-started/installation", kind: "brand" },
-                { label: "Read Quick Start", href: "/getting-started/quick-start", kind: "alt" },
+                { label: "Install gflow", href: "/getting-started/installation" },
+                { label: "Read Quick Start", href: "/getting-started/quick-start" },
             ],
         },
     },
@@ -300,11 +162,11 @@ const copies = {
         hero: {
             eyebrow: "面向共享机器的单节点调度",
             title: "让一台 Linux 机器拥有真正的任务调度器",
-            lead: "在共享工作站上，用轻量 CLI 和本地 daemon 完成 GPU 或 CPU 任务的提交、排队与查看。",
+            lead: "一个轻量 CLI 加本地 daemon，完成 GPU / CPU 任务的提交、调度与查看。",
             actions: [
-                { label: "快速开始", href: "/zh-CN/getting-started/quick-start", kind: "brand" },
-                { label: "安装指南", href: "/zh-CN/getting-started/installation", kind: "alt" },
-                { label: "命令速查", href: "/zh-CN/reference/quick-reference", kind: "ghost" },
+                { label: "快速开始", href: "/zh-CN/getting-started/quick-start" },
+                { label: "安装指南", href: "/zh-CN/getting-started/installation" },
+                { label: "命令速查", href: "/zh-CN/reference/quick-reference" },
             ],
             trust: [
                 "单节点设计",
@@ -312,197 +174,87 @@ const copies = {
                 "基于 tmux 的执行",
                 "可供 Agent 使用的 MCP",
             ],
-            stats: [
-                {
-                    value: "CLI 优先",
-                    label: "用熟悉的命令完成排队、控制和查看。",
-                },
-                {
-                    value: "可恢复",
-                    label: "随时 attach、追踪日志、重做任务。",
-                },
-                {
-                    value: "策略明确",
-                    label: "明确声明 GPU、显存、优先级、预约和依赖。",
-                },
-            ],
         },
-        panel: {
-            title: "工作站会话",
-            lines: [
-                "$ gflowd up",
-                "daemon ready on 127.0.0.1:5577",
-                "$ gbatch --gpus 1 --project vision python train.py",
-                "submitted batch job 184",
-                "$ gqueue",
-                "JOBID  NAME    ST  TIME      GPU  NODELIST(REASON)",
-                "184    train   R   00:12:41  1    0",
-                "185    eval    PD  -         0    (WaitingForDependency)",
-                "$ gjob log 184",
-                "step=420 loss=0.184 throughput=178 img/s",
-            ],
-            queueCardTitle: "队列快照",
-            queueCardValues: [
-                { label: "运行中", value: "04" },
-                { label: "排队中", value: "09" },
-                { label: "挂起", value: "01" },
-            ],
-            gpuCardTitle: "GPU 策略",
-            gpuCardValues: [
-                { label: "可见设备", value: "0,1,2,3" },
-                { label: "共享方式", value: "按显存调度" },
-            ],
-        },
+        panel: { title: "工作站会话" },
         problem: {
             eyebrow: "为什么需要它",
             title: "当一台机器不再只属于你",
-            lead: "一旦工作站开始共享，临时 tmux 会话和口头约定很快就会失效。",
-            painTitle: "没有队列纪律时",
+            lead: "一旦机器开始共享，临时 tmux 和口头约定就会失效。",
+            painTitle: "没有纪律时",
             painItems: [
-                "长任务会和交互式工作互相打架。",
-                "失败后难以恢复，因为状态和日志散落在不同地方。",
-                "GPU 使用规则只能靠经验相传。",
+                "长任务和交互式工作互相打架。",
+                "失败后日志散落，没有状态可恢复。",
+                "GPU 规则靠经验，而不是策略。",
             ],
-            valueTitle: "使用 gflow 后",
+            valueTitle: "用 gflow 后",
             valueItems: [
-                "本地 daemon 统一保存状态和队列控制。",
-                "每个任务都有可查看、可恢复的生命周期。",
-                "资源和依赖在提交时明确声明。",
+                "一个 daemon 统一管理状态与队列。",
+                "每个任务可查看、可恢复。",
+                "资源与依赖在提交前明确声明。",
             ],
         },
         workflow: {
             eyebrow: "工作流",
-            title: "四条命令进入可控状态",
+            title: "四条命令，一次可控运行",
             steps: [
-                {
-                    label: "01",
-                    command: "gflowd up",
-                    description: "启动本地调度器。",
-                },
-                {
-                    label: "02",
-                    command: "gbatch --gpus 1 python train.py",
-                    description: "用明确的资源声明提交命令或脚本。",
-                },
-                {
-                    label: "03",
-                    command: "gqueue",
-                    description: "查看运行中、排队中或已完成任务。",
-                },
-                {
-                    label: "04",
-                    command: "gjob log <job_id>",
-                    description: "追踪日志，或在需要时 attach 会话。",
-                },
+                { idx: "01", cmd: "gflowd up", label: "启动 daemon" },
+                { idx: "02", cmd: "gbatch --gpus 1", label: "提交任务" },
+                { idx: "03", cmd: "gqueue", label: "查看调度" },
+                { idx: "04", cmd: "gjob log <id>", label: "跟踪日志" },
             ],
         },
         capabilities: {
             eyebrow: "能力概览",
-            title: "为日常工作站使用而设计",
+            title: "为日常工作站而设计",
             items: [
-                {
-                    title: "队列与生命周期",
-                    body: "支持提交、挂起、恢复、取消、更新与重做，并提供可检查的状态模型。",
-                },
-                {
-                    title: "GPU 感知调度",
-                    body: "直接声明 GPU 数量，开启共享模式，并设置显存上限。",
-                },
-                {
-                    title: "工作流编排",
-                    body: "通过依赖、数组任务和参数扫描组织多阶段任务。",
-                },
-                {
-                    title: "可观测性",
-                    body: "通过表格、树状、JSON、CSV 或 YAML 查看队列状态。",
-                },
-                {
-                    title: "可恢复执行",
-                    body: "每个任务都运行在独立 tmux 会话中，便于日志查看和恢复。",
-                },
-                {
-                    title: "自动化与 AI 集成",
-                    body: "通过本地 MCP server 暴露调度操作，供 Agent 调用。",
-                },
+                { title: "队列与生命周期", body: "提交、挂起、取消、更新与重做任务。" },
+                { title: "GPU 感知调度", body: "声明 GPU、共享、并限制显存。" },
+                { title: "工作流编排", body: "用依赖、数组任务与参数扫描串联。" },
+                { title: "可观测性", body: "以表格、树、JSON、CSV 或 YAML 查看状态。" },
+                { title: "可恢复执行", body: "每个任务都跑在独立 tmux 会话里。" },
+                { title: "自动化与 AI", body: "通过本地 MCP server 驱动调度。" },
             ],
         },
         scenarios: {
             eyebrow: "适用场景",
-            title: "常见场景",
+            title: "适用场景",
             items: [
-                {
-                    title: "共享实验室 GPU 服务器",
-                    body: "多人共用一台机器时，用明确规则替代口头协调。",
-                },
-                {
-                    title: "个人研究主机",
-                    body: "让长时间实验保持结构化、可恢复。",
-                },
-                {
-                    title: "本地评测与自动化流水线",
-                    body: "用依赖关系串联预处理、训练、评测和汇总。",
-                },
+                { title: "共享实验室 GPU 服务器", body: "多人共用一台机器，用规则替代口头协调。" },
+                { title: "个人研究主机", body: "让长时间实验保持结构化、可恢复。" },
+                { title: "本地评测流水线", body: "串联预处理、训练、评测与汇总。" },
             ],
         },
         pathways: {
-            eyebrow: "文档入口",
-            title: "按你的阶段开始",
+            eyebrow: "文档",
+            title: "从你的阶段开始",
             items: [
-                {
-                    title: "安装并启动",
-                    body: "安装二进制、生成默认配置，并启动 daemon。",
-                    href: "/zh-CN/getting-started/installation",
-                    cta: "查看安装指南",
-                },
-                {
-                    title: "学习第一个流程",
-                    body: "从启动调度器到提交任务、查看队列、读取日志。",
-                    href: "/zh-CN/getting-started/quick-start",
-                    cta: "查看快速开始",
-                },
-                {
-                    title: "直接查命令",
-                    body: "快速浏览 `gflowd`、`gbatch`、`gqueue`、`gjob`、`gctl` 等命令。",
-                    href: "/zh-CN/reference/quick-reference",
-                    cta: "查看命令速查",
-                },
-                {
-                    title: "连接你的 Agent",
-                    body: "把 gflow 作为本地 MCP server 接给 Agent 工具。",
-                    href: "/zh-CN/ai-integration/mcp-and-skills",
-                    cta: "查看 AI 集成",
-                },
+                { title: "安装并启动", body: "安装、配置并启动 daemon。", href: "/zh-CN/getting-started/installation", cta: "安装指南" },
+                { title: "第一个流程", body: "提交任务、查看队列、读取日志。", href: "/zh-CN/getting-started/quick-start", cta: "快速开始" },
+                { title: "命令速查", body: "gflowd、gbatch、gqueue、gjob、gctl 速查。", href: "/zh-CN/reference/quick-reference", cta: "命令速查" },
+                { title: "连接 Agent", body: "把 gflow 作为本地 MCP server 运行。", href: "/zh-CN/ai-integration/mcp-and-skills", cta: "AI 集成" },
             ],
         },
         mcp: {
             eyebrow: "AI 集成",
-            title: "把调度操作暴露成 Agent 可调用的工具",
-            lead: "将 gflow 作为本地 stdio MCP server 运行后，Agent CLI 可以直接查看队列并驱动调度流程。",
+            title: "把调度操作变成 Agent 工具",
+            lead: "将 gflow 作为本地 stdio MCP server 运行，Agent CLI 可查看队列并驱动流程。",
             command: "gflow mcp serve",
             href: "/zh-CN/ai-integration/mcp-and-skills",
-            cta: "阅读 Agent、MCP 与 Skill",
+            cta: "阅读 AI 指南",
         },
         cta: {
-            title: "从你已经拥有的那台机器开始调度",
-            lead: "把这套文档当作运维手册。",
+            title: "从你已有的那台机器开始调度",
+            lead: "文档同时也是一本运维手册。",
             actions: [
-                { label: "安装 gflow", href: "/zh-CN/getting-started/installation", kind: "brand" },
-                { label: "阅读快速开始", href: "/zh-CN/getting-started/quick-start", kind: "alt" },
+                { label: "安装 gflow", href: "/zh-CN/getting-started/installation" },
+                { label: "阅读快速开始", href: "/zh-CN/getting-started/quick-start" },
             ],
         },
     },
-} as const;
+};
 
 const currentLocale = computed(() => (props.locale === "zh-CN" ? "zh-CN" : "en"));
 const copy = computed(() => copies[currentLocale.value]);
-const terminalLines = computed(() => copy.value.panel.lines.map(classifyTerminalLine));
-const workflowSteps = computed(() =>
-    copy.value.workflow.steps.map((step) => ({
-        ...step,
-        commandHtml: highlightShell(step.command),
-    })),
-);
-const mcpCommandHtml = computed(() => highlightShell(copy.value.mcp.command));
 
 function pad(n: number) {
     return String(n).padStart(2, "0");
@@ -533,21 +285,30 @@ function pad(n: number) {
             </div>
         </header>
 
-        <!-- TERMINAL -->
+        <!-- TERMINAL (animated) -->
         <section class="lp-section">
             <div class="lp-container">
                 <div class="lp-terminal">
                     <div class="lp-terminal-head">
-                        <span class="lp-terminal-path">{{ copy.panel.title }}</span>
+                        <span class="lp-terminal-path"><span class="lp-live" aria-hidden="true"></span>{{ copy.panel.title }}</span>
                         <span class="lp-terminal-meta">gflowd&nbsp;·&nbsp;127.0.0.1:5577</span>
                     </div>
                     <div class="lp-terminal-body">
                         <div
-                            v-for="(line, index) in terminalLines"
-                            :key="index"
-                            :class="['lp-tl', `lp-tl-${line.kind}`]"
-                            v-html="line.html"
-                        />
+                            v-for="(row, i) in TERMINAL"
+                            :key="i"
+                            v-show="frame >= row.at"
+                            :class="['lp-tl', `lp-tl-${row.kind}`]"
+                        >
+                            <template v-if="row.kind === 'cmd'">
+                                <span class="lp-prompt">$</span><span class="lp-cmd-text">{{ row.text }}</span><span v-if="i === activeCmd" class="lp-cursor" aria-hidden="true"></span>
+                            </template>
+                            <template v-else-if="row.kind === 'thead'"><span v-for="c in row.cells" :key="c" class="lp-th">{{ c }}</span></template>
+                            <template v-else-if="row.kind === 'trow'">
+                                <span class="lp-td">{{ row.id }}</span><span class="lp-td">{{ row.name }}</span><span :class="['lp-td', 'lp-state', frame >= JOB_RUNS_AT ? 'is-run' : 'is-pend']">{{ frame >= JOB_RUNS_AT ? "RUNNING" : "PENDING" }}</span><span class="lp-td">{{ row.gpu }}</span><span class="lp-td">{{ row.node }}</span>
+                            </template>
+                            <template v-else>{{ row.text }}</template>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -578,17 +339,19 @@ function pad(n: number) {
             </div>
         </section>
 
-        <!-- 02 · HOW IT WORKS -->
+        <!-- 02 · HOW IT WORKS (animated pipeline) -->
         <section class="lp-section">
             <div class="lp-container">
                 <div class="lp-sec-head">
                     <p class="lp-sec-eyebrow"><span class="lp-sec-idx" aria-hidden="true">{{ pad(2) }}</span>{{ copy.workflow.eyebrow }}</p>
                     <h2 class="lp-sec-title">{{ copy.workflow.title }}</h2>
                 </div>
-                <div class="lp-grid lp-grid-4">
-                    <div class="lp-cell lp-step" v-for="step in workflowSteps" :key="step.label">
-                        <code class="lp-step-cmd" v-html="step.commandHtml"></code>
-                        <p class="lp-step-desc">{{ step.description }}</p>
+                <div class="lp-flow">
+                    <div v-for="(s, i) in copy.workflow.steps" :key="s.idx" class="lp-flow-stage" :style="({ '--i': i } as any)">
+                        <span class="lp-flow-bar" aria-hidden="true"></span>
+                        <span class="lp-flow-idx">{{ s.idx }}</span>
+                        <code class="lp-flow-cmd">{{ s.cmd }}</code>
+                        <span class="lp-flow-label">{{ s.label }}</span>
                     </div>
                 </div>
             </div>
@@ -653,7 +416,7 @@ function pad(n: number) {
                     <p class="lp-band-lead">{{ copy.mcp.lead }}</p>
                 </div>
                 <div class="lp-band-action">
-                    <pre class="lp-band-cmd"><code v-html="mcpCommandHtml"></code></pre>
+                    <pre class="lp-band-cmd"><code class="lp-band-cmd-text">{{ copy.mcp.command }}</code></pre>
                     <a class="lp-btn lp-btn-inv" :href="copy.mcp.href">{{ copy.mcp.cta }}<span class="lp-arrow" aria-hidden="true">→</span></a>
                 </div>
             </div>

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,33 +1,39 @@
 :root {
-    --lp-bg: #f6f1e8;
-    --lp-bg-elevated: rgba(255, 255, 255, 0.88);
-    --lp-bg-strong: #fffaf2;
-    --lp-text: #18212b;
-    --lp-text-muted: #55616e;
-    --lp-border: rgba(24, 33, 43, 0.12);
-    --lp-shadow: 0 20px 70px rgba(15, 23, 42, 0.12);
-    --lp-accent: #c56a1b;
-    --lp-accent-strong: #a14b0f;
-    --lp-accent-soft: rgba(197, 106, 27, 0.14);
+    --lp-bg: #f3f6fc;
+    --lp-bg-elevated: rgba(255, 255, 255, 0.82);
+    --lp-bg-strong: #ffffff;
+    --lp-text: #0e1a30;
+    --lp-text-muted: #52607a;
+    --lp-border: rgba(14, 26, 48, 0.1);
+    --lp-shadow: 0 24px 70px rgba(30, 41, 59, 0.1);
+    --lp-accent: #2563eb;
+    --lp-accent-strong: #1d4ed8;
+    --lp-accent-soft: rgba(37, 99, 235, 0.09);
+    --lp-indigo: #4f46e5;
     --lp-teal: #0d766e;
-    --lp-terminal: #0f1722;
-    --lp-terminal-text: #dbe6f4;
+    --lp-terminal: #0d1526;
+    --lp-terminal-text: #d9e3f4;
+    --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
+    --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
 
 .dark {
-    --lp-bg: #0b1220;
-    --lp-bg-elevated: rgba(13, 23, 34, 0.84);
-    --lp-bg-strong: #101a2a;
-    --lp-text: #edf2f7;
-    --lp-text-muted: #a4b2c2;
-    --lp-border: rgba(148, 163, 184, 0.18);
-    --lp-shadow: 0 24px 90px rgba(0, 0, 0, 0.35);
-    --lp-accent: #ef9a48;
-    --lp-accent-strong: #ffb86b;
-    --lp-accent-soft: rgba(239, 154, 72, 0.14);
+    --lp-bg: #070c19;
+    --lp-bg-elevated: rgba(15, 23, 42, 0.66);
+    --lp-bg-strong: #0f1a30;
+    --lp-text: #eef2f9;
+    --lp-text-muted: #9fadc4;
+    --lp-border: rgba(148, 163, 184, 0.16);
+    --lp-shadow: 0 30px 90px rgba(0, 0, 0, 0.5);
+    --lp-accent: #60a5fa;
+    --lp-accent-strong: #93c5fd;
+    --lp-accent-soft: rgba(96, 165, 250, 0.12);
+    --lp-indigo: #818cf8;
     --lp-teal: #4fd1c5;
-    --lp-terminal: #08111d;
-    --lp-terminal-text: #d7e6ff;
+    --lp-terminal: #0e1a33;
+    --lp-terminal-text: #d6e2f7;
+    --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
+    --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
 
 .landing-page-shell .VPDoc {
@@ -67,23 +73,24 @@
     overflow: hidden;
     padding: 3rem 0 5rem;
     background:
-        radial-gradient(
-            circle at top left,
-            rgba(13, 118, 110, 0.14),
-            transparent 32rem
-        ),
-        radial-gradient(
-            circle at top right,
-            rgba(197, 106, 27, 0.18),
-            transparent 28rem
-        ),
+        radial-gradient(circle at top left, rgba(79, 70, 229, 0.16), transparent 34rem),
+        radial-gradient(circle at top right, rgba(37, 99, 235, 0.2), transparent 30rem),
+        radial-gradient(circle at 50% 120%, rgba(13, 148, 136, 0.1), transparent 42rem),
         linear-gradient(
             180deg,
             var(--lp-bg) 0%,
-            color-mix(in srgb, var(--lp-bg) 82%, #ffffff 18%) 100%
+            color-mix(in srgb, var(--lp-bg) 86%, #ffffff 14%) 100%
         );
     color: var(--lp-text);
     font-family: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
+}
+
+.dark .landing-page {
+    background:
+        radial-gradient(circle at top left, rgba(79, 70, 229, 0.26), transparent 36rem),
+        radial-gradient(circle at top right, rgba(37, 99, 235, 0.28), transparent 32rem),
+        radial-gradient(circle at 50% 120%, rgba(13, 148, 136, 0.14), transparent 44rem),
+        linear-gradient(180deg, var(--lp-bg) 0%, var(--lp-bg) 100%);
 }
 
 .landing-page::before {
@@ -94,7 +101,12 @@
         linear-gradient(var(--lp-border) 1px, transparent 1px),
         linear-gradient(90deg, var(--lp-border) 1px, transparent 1px);
     background-size: 72px 72px;
-    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.35), transparent 70%);
+    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.4), transparent 68%);
+    -webkit-mask-image: linear-gradient(
+        180deg,
+        rgba(0, 0, 0, 0.4),
+        transparent 68%
+    );
     pointer-events: none;
 }
 
@@ -103,6 +115,24 @@
     z-index: 1;
     width: min(1180px, calc(100vw - 3rem));
     margin: 0 auto;
+}
+
+/* ---------- typography system ---------- */
+.landing-page h1,
+.landing-page h2,
+.landing-page h3,
+.lp-stat-value,
+.lp-brand {
+    font-family: var(--lp-font-display);
+}
+
+.lp-terminal-body,
+.lp-terminal-line-command,
+.lp-code-inline,
+.lp-step-card code,
+.lp-mcp-row code,
+.lp-step-label {
+    font-family: var(--lp-font-mono);
 }
 
 .lp-hero {
@@ -123,10 +153,10 @@
     border: 1px solid var(--lp-border);
     border-radius: 999px;
     background: color-mix(in srgb, var(--lp-bg-elevated) 82%, transparent);
-    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.07);
-    font-size: 0.95rem;
+    box-shadow: 0 12px 30px rgba(30, 41, 59, 0.08);
+    font-size: 0.98rem;
     font-weight: 700;
-    letter-spacing: 0.03em;
+    letter-spacing: 0.01em;
 }
 
 .lp-brand-logo {
@@ -135,20 +165,36 @@
 }
 
 .lp-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.55rem;
     margin: 0 0 0.9rem;
     color: var(--lp-accent-strong);
-    font-size: 0.88rem;
+    font-size: 0.82rem;
     font-weight: 700;
     letter-spacing: 0.14em;
     text-transform: uppercase;
 }
 
+.lp-eyebrow::before {
+    content: "";
+    width: 1.7rem;
+    height: 2px;
+    border-radius: 2px;
+    background: linear-gradient(
+        90deg,
+        var(--lp-accent),
+        var(--lp-indigo)
+    );
+}
+
 .lp-title {
     margin: 0;
-    font-size: clamp(3rem, 6vw, 5.4rem);
-    line-height: 0.95;
-    letter-spacing: -0.05em;
-    max-width: 12ch;
+    font-size: clamp(2.9rem, 6vw, 5.3rem);
+    line-height: 0.98;
+    letter-spacing: -0.045em;
+    font-weight: 700;
+    max-width: 13ch;
 }
 
 .lp-lead,
@@ -161,40 +207,44 @@
     color: var(--lp-text-muted);
     font-size: 1.04rem;
     line-height: 1.75;
+    font-family: var(--vp-font-family-base, "Inter", sans-serif);
 }
 
 .lp-lead {
     max-width: 44rem;
-    margin: 1.25rem 0 0;
-    font-size: 1.12rem;
+    margin: 1.4rem 0 0;
+    font-size: 1.14rem;
 }
 
 .lp-actions {
     display: flex;
     flex-wrap: wrap;
     gap: 0.9rem;
-    margin: 2rem 0 1.5rem;
+    margin: 2.1rem 0 1.6rem;
 }
 
 .lp-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 3rem;
-    padding: 0 1.1rem;
+    min-height: 3.1rem;
+    padding: 0 1.4rem;
     border: 1px solid transparent;
     border-radius: 999px;
     text-decoration: none;
-    font-weight: 700;
+    font-weight: 600;
+    font-family: var(--lp-font-display);
+    letter-spacing: 0.005em;
     transition:
         transform 180ms ease,
         border-color 180ms ease,
         background-color 180ms ease,
-        color 180ms ease;
+        color 180ms ease,
+        box-shadow 180ms ease;
 }
 
 .lp-button:hover {
-    transform: translateY(-1px);
+    transform: translateY(-2px);
 }
 
 .lp-button-brand {
@@ -203,8 +253,12 @@
         var(--lp-accent) 0%,
         var(--lp-accent-strong) 100%
     );
-    color: #fff7ee;
-    box-shadow: 0 18px 40px rgba(161, 75, 15, 0.24);
+    color: #f5f8ff;
+    box-shadow: 0 18px 42px rgba(37, 99, 235, 0.3);
+}
+
+.lp-button-brand:hover {
+    box-shadow: 0 22px 50px rgba(37, 99, 235, 0.4);
 }
 
 .lp-button-alt {
@@ -213,10 +267,18 @@
     color: var(--lp-text);
 }
 
+.lp-button-alt:hover {
+    border-color: color-mix(in srgb, var(--lp-accent) 45%, var(--lp-border));
+}
+
 .lp-button-ghost {
     color: var(--lp-text);
     border-color: transparent;
     background: transparent;
+}
+
+.lp-button-ghost:hover {
+    color: var(--lp-accent-strong);
 }
 
 .lp-trust {
@@ -229,19 +291,32 @@
 }
 
 .lp-trust li {
-    padding: 0.45rem 0.8rem;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.45rem;
+    padding: 0.45rem 0.85rem;
     border: 1px solid var(--lp-border);
     border-radius: 999px;
     background: color-mix(in srgb, var(--lp-bg-elevated) 86%, transparent);
     font-size: 0.92rem;
     color: var(--lp-text);
+    font-family: var(--vp-font-family-base, "Inter", sans-serif);
+}
+
+.lp-trust li::before {
+    content: "";
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--lp-accent);
+    box-shadow: 0 0 0 3px var(--lp-accent-soft);
 }
 
 .lp-stats {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
-    margin-top: 1.5rem;
+    margin-top: 1.6rem;
 }
 
 .lp-stat-card,
@@ -256,22 +331,56 @@
     backdrop-filter: blur(10px);
 }
 
+.lp-stat-card,
+.lp-compare-card,
+.lp-step-card,
+.lp-card {
+    transition:
+        transform 200ms ease,
+        border-color 200ms ease,
+        box-shadow 200ms ease;
+}
+
+.lp-stat-card:hover,
+.lp-compare-card:hover,
+.lp-step-card:hover,
+.lp-card:hover {
+    transform: translateY(-4px);
+    border-color: color-mix(in srgb, var(--lp-accent) 38%, var(--lp-border));
+    box-shadow: 0 30px 80px rgba(30, 41, 59, 0.14);
+}
+
+.dark .lp-stat-card:hover,
+.dark .lp-compare-card:hover,
+.dark .lp-step-card:hover,
+.dark .lp-card:hover {
+    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.5);
+}
+
 .lp-stat-card {
-    padding: 1.1rem 1.15rem;
-    border-radius: 1.2rem;
+    padding: 1.2rem 1.2rem;
+    border-radius: 1.25rem;
 }
 
 .lp-stat-value {
-    margin: 0 0 0.35rem;
-    font-size: 1.05rem;
-    font-weight: 800;
-    letter-spacing: 0.01em;
+    margin: 0 0 0.4rem;
+    font-size: 1.28rem;
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    background: linear-gradient(
+        120deg,
+        var(--lp-accent-strong),
+        var(--lp-indigo)
+    );
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
 }
 
 .lp-stat-label {
     margin: 0;
-    font-size: 0.95rem;
-    line-height: 1.6;
+    font-size: 0.94rem;
+    line-height: 1.55;
 }
 
 .lp-hero-visual {
@@ -284,16 +393,24 @@
     position: absolute;
     inset: 2rem 0 4rem 0;
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.06);
+    border: 1px solid rgba(255, 255, 255, 0.07);
     border-radius: 1.7rem;
     background: linear-gradient(
         180deg,
-        rgba(16, 29, 43, 0.96),
-        rgba(7, 13, 23, 0.98)
+        rgba(14, 26, 46, 0.98),
+        rgba(7, 14, 26, 0.99)
     );
     box-shadow:
-        0 30px 100px rgba(0, 0, 0, 0.34),
-        inset 0 1px 0 rgba(255, 255, 255, 0.04);
+        0 40px 110px rgba(8, 15, 30, 0.42),
+        0 0 0 1px rgba(37, 99, 235, 0.12),
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+
+.dark .lp-terminal {
+    box-shadow:
+        0 40px 120px rgba(0, 0, 0, 0.55),
+        0 0 60px rgba(37, 99, 235, 0.16),
+        inset 0 1px 0 rgba(255, 255, 255, 0.05);
 }
 
 .lp-terminal-bar {
@@ -301,8 +418,8 @@
     align-items: center;
     gap: 0.5rem;
     padding: 0.95rem 1.1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-    color: rgba(219, 230, 244, 0.78);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
+    color: rgba(217, 227, 244, 0.8);
     font-size: 0.88rem;
 }
 
@@ -311,29 +428,30 @@
     width: 0.72rem;
     height: 0.72rem;
     border-radius: 50%;
-    background: rgba(239, 154, 72, 0.72);
+    background: var(--lp-accent);
 }
 
 .lp-terminal-bar span:nth-child(2) {
-    background: rgba(79, 209, 197, 0.72);
+    background: var(--lp-indigo);
 }
 
 .lp-terminal-bar span:nth-child(3) {
-    background: rgba(96, 165, 250, 0.72);
+    background: var(--lp-teal);
 }
 
 .lp-terminal-bar strong {
     margin-left: 0.5rem;
-    font-weight: 700;
+    font-weight: 600;
+    letter-spacing: 0.01em;
 }
 
 .lp-terminal-body {
     margin: 0;
     padding: 1.35rem 1.4rem 1.6rem;
     color: var(--lp-terminal-text);
-    font-family: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
-    font-size: 0.9rem;
-    line-height: 1.8;
+    font-family: var(--lp-font-mono);
+    font-size: 0.88rem;
+    line-height: 1.85;
     white-space: pre-wrap;
 }
 
@@ -362,12 +480,12 @@
 .lp-terminal-line-table,
 .lp-terminal-line-metrics,
 .lp-terminal-line-output {
-    color: rgba(219, 230, 244, 0.88);
+    color: rgba(217, 227, 244, 0.88);
 }
 
 .lp-code-inline,
 .lp-terminal-line-command {
-    font-family: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
+    font-family: var(--lp-font-mono);
 }
 
 .lp-code-inline span[style],
@@ -395,25 +513,25 @@
 }
 
 .lp-floating-card-queue {
-    top: 0;
-    right: -1rem;
-    width: 16rem;
+    top: 0.2rem;
+    right: -0.6rem;
+    width: 15rem;
     animation: lp-float 5.5s ease-in-out infinite;
 }
 
 .lp-floating-card-gpu {
-    bottom: 1rem;
-    left: -1.25rem;
-    width: 14rem;
+    bottom: 1.4rem;
+    left: -0.75rem;
+    width: 13rem;
     animation: lp-float 6.3s ease-in-out infinite;
 }
 
 .lp-floating-title,
 .lp-compare-label {
     margin: 0 0 0.85rem;
-    font-size: 0.82rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
+    font-size: 0.76rem;
+    font-weight: 700;
+    letter-spacing: 0.13em;
     text-transform: uppercase;
     color: var(--lp-accent-strong);
 }
@@ -428,18 +546,19 @@
 .lp-floating-stack div {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.25rem;
 }
 
 .lp-floating-grid span,
 .lp-floating-stack span {
     color: var(--lp-text-muted);
-    font-size: 0.82rem;
+    font-size: 0.8rem;
 }
 
 .lp-floating-grid strong,
 .lp-floating-stack strong {
-    font-size: 1.05rem;
+    font-size: 1.02rem;
+    font-family: var(--lp-font-mono);
 }
 
 .lp-floating-stack {
@@ -452,44 +571,50 @@
 }
 
 .lp-section + .lp-section {
-    margin-top: 1rem;
+    margin-top: 3.4rem;
 }
 
 .lp-section-heading {
     max-width: 44rem;
-    margin-bottom: 1.6rem;
+    margin-bottom: 1.9rem;
 }
 
 .lp-section-heading h2,
 .lp-closing h2 {
     margin: 0;
-    font-size: clamp(2rem, 4vw, 3.3rem);
-    line-height: 1.03;
-    letter-spacing: -0.04em;
+    font-size: clamp(1.9rem, 4vw, 3.2rem);
+    line-height: 1.05;
+    letter-spacing: -0.035em;
+    font-weight: 700;
 }
 
 .lp-section-heading p {
-    margin: 0.9rem 0 0;
+    margin: 1rem 0 0;
 }
 
 .lp-compare {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 1.1rem;
 }
 
 .lp-compare-card {
-    padding: 1.4rem;
+    padding: 1.5rem;
     border-radius: 1.5rem;
 }
 
 .lp-compare-card-accent {
+    border-color: color-mix(
+        in srgb,
+        var(--lp-accent) 28%,
+        var(--lp-border)
+    );
     background: linear-gradient(
         180deg,
         color-mix(
             in srgb,
-            var(--lp-accent-soft) 60%,
-            var(--lp-bg-elevated) 40%
+            var(--lp-accent-soft) 70%,
+            var(--lp-bg-elevated) 30%
         ),
         color-mix(in srgb, var(--lp-bg-elevated) 94%, transparent)
     );
@@ -497,44 +622,59 @@
 
 .lp-compare-card ul {
     margin: 0;
-    padding-left: 1.1rem;
+    padding-left: 1.15rem;
+}
+
+.lp-compare-card li {
+    margin-top: 0.55rem;
+}
+
+.lp-compare-card li::marker {
+    color: var(--lp-accent);
 }
 
 .lp-step-grid,
 .lp-card-grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1rem;
+    gap: 1.1rem;
 }
 
 .lp-step-card,
 .lp-card {
-    padding: 1.3rem;
-    border-radius: 1.45rem;
+    padding: 1.4rem;
+    border-radius: 1.5rem;
 }
 
 .lp-step-label {
     display: inline-flex;
-    margin-bottom: 1rem;
+    align-items: center;
+    margin-bottom: 1.1rem;
+    padding: 0.18rem 0.6rem;
+    border-radius: 0.55rem;
+    background: var(--lp-accent-soft);
     color: var(--lp-accent-strong);
-    font-size: 0.9rem;
-    font-weight: 800;
-    letter-spacing: 0.12em;
+    font-size: 0.82rem;
+    font-weight: 600;
+    letter-spacing: 0.06em;
 }
 
 .lp-step-card code,
 .lp-mcp-row code {
-    font-family: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
-    font-size: 0.94rem;
+    font-family: var(--lp-font-mono);
 }
 
-.lp-step-card code,
-.lp-mcp-row code {
-    display: inline-block;
-    padding: 0.6rem 0.75rem;
-    border-radius: 0.9rem;
+.lp-step-card code {
+    display: flex;
+    align-items: center;
+    min-height: 3.5em;
+    padding: 0.6rem 0.8rem;
+    border-radius: 0.85rem;
     background: var(--lp-terminal);
     color: var(--lp-terminal-text);
+    font-size: 0.85rem;
+    line-height: 1.5;
+    overflow-x: auto;
 }
 
 .lp-code-inline {
@@ -543,16 +683,21 @@
 
 .lp-step-card p,
 .lp-card p {
-    margin: 1rem 0 0;
+    margin: 1.05rem 0 0;
 }
 
 .lp-card h3 {
     margin: 0;
-    font-size: 1.18rem;
-    line-height: 1.25;
+    font-size: 1.16rem;
+    line-height: 1.28;
+    letter-spacing: -0.01em;
 }
 
 .lp-card-grid-scenarios {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.lp-card-grid-caps {
     grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
@@ -560,30 +705,42 @@
     background: linear-gradient(
         180deg,
         color-mix(in srgb, var(--lp-bg-elevated) 95%, transparent),
-        color-mix(in srgb, var(--lp-accent-soft) 30%, transparent)
+        color-mix(in srgb, var(--lp-accent-soft) 34%, transparent)
     );
 }
 
 .lp-card-link a {
     display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
     margin-top: 1.1rem;
-    color: var(--lp-teal);
-    font-weight: 700;
+    color: var(--lp-accent-strong);
+    font-weight: 600;
     text-decoration: none;
+    transition: gap 180ms ease, color 180ms ease;
 }
 
 .lp-card-link a:hover {
-    text-decoration: underline;
+    gap: 0.55rem;
+}
+
+.lp-card-link a::after {
+    content: "→";
+    font-family: var(--lp-font-mono);
 }
 
 .lp-mcp-callout {
     margin-top: 1.5rem;
-    padding: 1.75rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 1.8rem;
+    padding: 2rem;
+    border: 1px solid color-mix(
+        in srgb,
+        var(--lp-accent) 24%,
+        var(--lp-border)
+    );
+    border-radius: 1.9rem;
     background: linear-gradient(
         135deg,
-        color-mix(in srgb, var(--lp-accent-soft) 36%, transparent),
+        color-mix(in srgb, var(--lp-accent-soft) 44%, transparent),
         color-mix(in srgb, var(--lp-bg-elevated) 92%, transparent)
     );
     box-shadow: var(--lp-shadow);
@@ -594,12 +751,12 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 1rem;
-    margin-top: 1.25rem;
+    margin-top: 1.35rem;
 }
 
 .lp-mcp-row pre {
     margin: 0;
-    padding: 0.95rem 1.1rem;
+    padding: 0.95rem 1.2rem;
     border-radius: 1rem;
     background: var(--lp-terminal);
     color: var(--lp-terminal-text);
@@ -612,27 +769,29 @@
 }
 
 .lp-closing {
-    margin-top: 2.5rem;
-    padding: 2rem;
+    margin-top: 3rem;
+    padding: 3rem 2rem;
     border-radius: 2rem;
     text-align: center;
     background:
-        radial-gradient(
-            circle at top,
-            rgba(197, 106, 27, 0.16),
-            transparent 70%
-        ),
+        radial-gradient(circle at top, rgba(37, 99, 235, 0.16), transparent 70%),
+        radial-gradient(circle at bottom right, rgba(79, 70, 229, 0.14), transparent 60%),
         color-mix(in srgb, var(--lp-bg-elevated) 95%, transparent);
+}
+
+.lp-closing h2 {
+    max-width: 20ch;
+    margin: 0 auto;
 }
 
 .lp-closing p {
     max-width: 42rem;
-    margin: 0.9rem auto 0;
+    margin: 1rem auto 0;
 }
 
 .lp-closing .lp-actions {
     justify-content: center;
-    margin-bottom: 0;
+    margin: 2rem 0 0;
 }
 
 @keyframes lp-rise {
@@ -656,6 +815,14 @@
     }
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .lp-hero-visual,
+    .lp-floating-card-queue,
+    .lp-floating-card-gpu {
+        animation: none;
+    }
+}
+
 @media (max-width: 1100px) {
     .lp-hero {
         grid-template-columns: 1fr;
@@ -668,7 +835,8 @@
     }
 
     .lp-step-grid,
-    .lp-card-grid {
+    .lp-card-grid,
+    .lp-card-grid-caps {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
@@ -687,7 +855,7 @@
     }
 
     .lp-title {
-        font-size: clamp(2.5rem, 16vw, 4rem);
+        font-size: clamp(2.4rem, 15vw, 3.8rem);
     }
 
     .lp-hero-visual {
@@ -711,12 +879,13 @@
     .lp-compare,
     .lp-step-grid,
     .lp-card-grid,
-    .lp-card-grid-scenarios {
+    .lp-card-grid-scenarios,
+    .lp-card-grid-caps {
         grid-template-columns: 1fr;
     }
 
     .lp-mcp-callout,
     .lp-closing {
-        padding: 1.35rem;
+        padding: 1.5rem;
     }
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,37 +1,33 @@
 :root {
-    --lp-bg: #f3f6fc;
-    --lp-bg-elevated: rgba(255, 255, 255, 0.82);
-    --lp-bg-strong: #ffffff;
-    --lp-text: #0e1a30;
-    --lp-text-muted: #52607a;
-    --lp-border: rgba(14, 26, 48, 0.1);
-    --lp-shadow: 0 24px 70px rgba(30, 41, 59, 0.1);
+    --lp-bg: #ffffff;
+    --lp-surface: #ffffff;
+    --lp-text: #0a0a0a;
+    --lp-text-muted: #52525b;
+    --lp-text-faint: #71717a;
+    --lp-border: #e4e4e7;
+    --lp-border-strong: #d4d4d8;
     --lp-accent: #2563eb;
-    --lp-accent-strong: #1d4ed8;
-    --lp-accent-soft: rgba(37, 99, 235, 0.09);
-    --lp-indigo: #4f46e5;
-    --lp-teal: #0d766e;
-    --lp-terminal: #0d1526;
-    --lp-terminal-text: #d9e3f4;
+    --lp-accent-hover: #1d4ed8;
+    --lp-accent-soft: #eff4ff;
+    --lp-terminal: #0a0a0a;
+    --lp-terminal-text: #e4e4e7;
     --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
     --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
 
 .dark {
-    --lp-bg: #070c19;
-    --lp-bg-elevated: rgba(15, 23, 42, 0.66);
-    --lp-bg-strong: #0f1a30;
-    --lp-text: #eef2f9;
-    --lp-text-muted: #9fadc4;
-    --lp-border: rgba(148, 163, 184, 0.16);
-    --lp-shadow: 0 30px 90px rgba(0, 0, 0, 0.5);
-    --lp-accent: #60a5fa;
-    --lp-accent-strong: #93c5fd;
-    --lp-accent-soft: rgba(96, 165, 250, 0.12);
-    --lp-indigo: #818cf8;
-    --lp-teal: #4fd1c5;
-    --lp-terminal: #0e1a33;
-    --lp-terminal-text: #d6e2f7;
+    --lp-bg: #0a0a0a;
+    --lp-surface: #0a0a0a;
+    --lp-text: #ededed;
+    --lp-text-muted: #a1a1aa;
+    --lp-text-faint: #8b8b8b;
+    --lp-border: #262626;
+    --lp-border-strong: #3f3f46;
+    --lp-accent: #3b82f6;
+    --lp-accent-hover: #60a5fa;
+    --lp-accent-soft: #0f1a30;
+    --lp-terminal: #0a0a0a;
+    --lp-terminal-text: #e4e4e7;
     --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
     --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
@@ -64,56 +60,22 @@
 }
 
 .landing-page-shell .VPNavBar {
-    background: color-mix(in srgb, var(--vp-nav-bg-color) 72%, transparent);
-    backdrop-filter: blur(18px);
+    background: var(--lp-bg);
+    backdrop-filter: none;
+    border-bottom: 1px solid var(--lp-border);
 }
 
 .landing-page {
     position: relative;
-    overflow: hidden;
-    padding: 3rem 0 5rem;
-    background:
-        radial-gradient(circle at top left, rgba(79, 70, 229, 0.16), transparent 34rem),
-        radial-gradient(circle at top right, rgba(37, 99, 235, 0.2), transparent 30rem),
-        radial-gradient(circle at 50% 120%, rgba(13, 148, 136, 0.1), transparent 42rem),
-        linear-gradient(
-            180deg,
-            var(--lp-bg) 0%,
-            color-mix(in srgb, var(--lp-bg) 86%, #ffffff 14%) 100%
-        );
+    padding: 4rem 0 6rem;
+    background: var(--lp-bg);
     color: var(--lp-text);
-    font-family: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
-}
-
-.dark .landing-page {
-    background:
-        radial-gradient(circle at top left, rgba(79, 70, 229, 0.26), transparent 36rem),
-        radial-gradient(circle at top right, rgba(37, 99, 235, 0.28), transparent 32rem),
-        radial-gradient(circle at 50% 120%, rgba(13, 148, 136, 0.14), transparent 44rem),
-        linear-gradient(180deg, var(--lp-bg) 0%, var(--lp-bg) 100%);
-}
-
-.landing-page::before {
-    content: "";
-    position: absolute;
-    inset: 0;
-    background-image:
-        linear-gradient(var(--lp-border) 1px, transparent 1px),
-        linear-gradient(90deg, var(--lp-border) 1px, transparent 1px);
-    background-size: 72px 72px;
-    mask-image: linear-gradient(180deg, rgba(0, 0, 0, 0.4), transparent 68%);
-    -webkit-mask-image: linear-gradient(
-        180deg,
-        rgba(0, 0, 0, 0.4),
-        transparent 68%
-    );
-    pointer-events: none;
+    font-family: var(--lp-font-display);
 }
 
 .landing-page section {
     position: relative;
-    z-index: 1;
-    width: min(1180px, calc(100vw - 3rem));
+    width: min(1120px, calc(100vw - 3rem));
     margin: 0 auto;
 }
 
@@ -138,63 +100,54 @@
 .lp-hero {
     display: grid;
     grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
-    gap: 3rem;
+    gap: 4rem;
     align-items: center;
-    min-height: calc(100vh - 11rem);
+    min-height: calc(100vh - 12rem);
     padding: 2rem 0 4rem;
 }
 
 .lp-brand {
     display: inline-flex;
     align-items: center;
-    gap: 0.8rem;
-    margin-bottom: 1.1rem;
-    padding: 0.5rem 0.9rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--lp-bg-elevated) 82%, transparent);
-    box-shadow: 0 12px 30px rgba(30, 41, 59, 0.08);
-    font-size: 0.98rem;
+    gap: 0.6rem;
+    margin-bottom: 1.75rem;
+    font-size: 1.05rem;
     font-weight: 700;
-    letter-spacing: 0.01em;
+    letter-spacing: -0.01em;
 }
 
 .lp-brand-logo {
-    width: 1.6rem;
-    height: 1.6rem;
+    width: 1.5rem;
+    height: 1.5rem;
 }
 
 .lp-eyebrow {
     display: flex;
     align-items: center;
-    gap: 0.55rem;
-    margin: 0 0 0.9rem;
-    color: var(--lp-accent-strong);
-    font-size: 0.82rem;
-    font-weight: 700;
-    letter-spacing: 0.14em;
+    gap: 0.6rem;
+    margin: 0 0 1.1rem;
+    color: var(--lp-text-faint);
+    font-size: 0.8rem;
+    font-weight: 600;
+    letter-spacing: 0.12em;
     text-transform: uppercase;
 }
 
 .lp-eyebrow::before {
     content: "";
-    width: 1.7rem;
+    width: 1.4rem;
     height: 2px;
-    border-radius: 2px;
-    background: linear-gradient(
-        90deg,
-        var(--lp-accent),
-        var(--lp-indigo)
-    );
+    background: var(--lp-accent);
 }
 
 .lp-title {
     margin: 0;
-    font-size: clamp(2.9rem, 6vw, 5.3rem);
-    line-height: 0.98;
-    letter-spacing: -0.045em;
+    font-size: clamp(2.7rem, 5.4vw, 4.6rem);
+    line-height: 1.02;
+    letter-spacing: -0.04em;
     font-weight: 700;
-    max-width: 13ch;
+    color: var(--lp-text);
+    max-width: 15ch;
 }
 
 .lp-lead,
@@ -205,253 +158,183 @@
 .lp-stat-label,
 .lp-compare-card li {
     color: var(--lp-text-muted);
-    font-size: 1.04rem;
-    line-height: 1.75;
+    font-size: 1.03rem;
+    line-height: 1.7;
     font-family: var(--vp-font-family-base, "Inter", sans-serif);
 }
 
 .lp-lead {
-    max-width: 44rem;
-    margin: 1.4rem 0 0;
-    font-size: 1.14rem;
+    max-width: 42rem;
+    margin: 1.5rem 0 0;
+    font-size: 1.12rem;
 }
 
 .lp-actions {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.9rem;
-    margin: 2.1rem 0 1.6rem;
+    align-items: center;
+    gap: 0.8rem;
+    margin: 2.2rem 0 0;
 }
 
 .lp-button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 3.1rem;
-    padding: 0 1.4rem;
+    min-height: 2.9rem;
+    padding: 0 1.2rem;
     border: 1px solid transparent;
-    border-radius: 999px;
+    border-radius: 8px;
     text-decoration: none;
     font-weight: 600;
+    font-size: 0.96rem;
     font-family: var(--lp-font-display);
-    letter-spacing: 0.005em;
     transition:
-        transform 180ms ease,
-        border-color 180ms ease,
-        background-color 180ms ease,
-        color 180ms ease,
-        box-shadow 180ms ease;
-}
-
-.lp-button:hover {
-    transform: translateY(-2px);
+        background-color 140ms ease,
+        border-color 140ms ease,
+        color 140ms ease;
 }
 
 .lp-button-brand {
-    background: linear-gradient(
-        135deg,
-        var(--lp-accent) 0%,
-        var(--lp-accent-strong) 100%
-    );
-    color: #f5f8ff;
-    box-shadow: 0 18px 42px rgba(37, 99, 235, 0.3);
+    background: var(--lp-accent);
+    color: #ffffff;
 }
 
 .lp-button-brand:hover {
-    box-shadow: 0 22px 50px rgba(37, 99, 235, 0.4);
+    background: var(--lp-accent-hover);
 }
 
 .lp-button-alt {
-    background: color-mix(in srgb, var(--lp-bg-elevated) 92%, transparent);
-    border-color: var(--lp-border);
+    background: var(--lp-surface);
+    border-color: var(--lp-border-strong);
     color: var(--lp-text);
 }
 
 .lp-button-alt:hover {
-    border-color: color-mix(in srgb, var(--lp-accent) 45%, var(--lp-border));
+    border-color: var(--lp-text-faint);
 }
 
 .lp-button-ghost {
-    color: var(--lp-text);
+    color: var(--lp-text-muted);
     border-color: transparent;
     background: transparent;
+    margin-left: 0.3rem;
 }
 
 .lp-button-ghost:hover {
-    color: var(--lp-accent-strong);
+    color: var(--lp-text);
 }
 
 .lp-trust {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.6rem 1.6rem;
     padding: 0;
-    margin: 0;
+    margin: 2rem 0 0;
     list-style: none;
 }
 
 .lp-trust li {
     display: inline-flex;
     align-items: center;
-    gap: 0.45rem;
-    padding: 0.45rem 0.85rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--lp-bg-elevated) 86%, transparent);
-    font-size: 0.92rem;
-    color: var(--lp-text);
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    color: var(--lp-text-muted);
     font-family: var(--vp-font-family-base, "Inter", sans-serif);
 }
 
 .lp-trust li::before {
     content: "";
-    width: 0.5rem;
-    height: 0.5rem;
+    width: 0.42rem;
+    height: 0.42rem;
     border-radius: 50%;
     background: var(--lp-accent);
-    box-shadow: 0 0 0 3px var(--lp-accent-soft);
 }
 
 .lp-stats {
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 1rem;
-    margin-top: 1.6rem;
-}
-
-.lp-stat-card,
-.lp-compare-card,
-.lp-step-card,
-.lp-card,
-.lp-floating-card,
-.lp-closing {
-    border: 1px solid var(--lp-border);
-    background: color-mix(in srgb, var(--lp-bg-elevated) 94%, transparent);
-    box-shadow: var(--lp-shadow);
-    backdrop-filter: blur(10px);
+    margin-top: 2.5rem;
 }
 
 .lp-stat-card,
 .lp-compare-card,
 .lp-step-card,
 .lp-card {
-    transition:
-        transform 200ms ease,
-        border-color 200ms ease,
-        box-shadow 200ms ease;
+    border: 1px solid var(--lp-border);
+    background: var(--lp-surface);
+    border-radius: 10px;
 }
 
 .lp-stat-card:hover,
 .lp-compare-card:hover,
 .lp-step-card:hover,
 .lp-card:hover {
-    transform: translateY(-4px);
-    border-color: color-mix(in srgb, var(--lp-accent) 38%, var(--lp-border));
-    box-shadow: 0 30px 80px rgba(30, 41, 59, 0.14);
-}
-
-.dark .lp-stat-card:hover,
-.dark .lp-compare-card:hover,
-.dark .lp-step-card:hover,
-.dark .lp-card:hover {
-    box-shadow: 0 34px 90px rgba(0, 0, 0, 0.5);
+    border-color: var(--lp-border-strong);
 }
 
 .lp-stat-card {
-    padding: 1.2rem 1.2rem;
-    border-radius: 1.25rem;
+    padding: 1.3rem 1.4rem;
 }
 
 .lp-stat-value {
     margin: 0 0 0.4rem;
-    font-size: 1.28rem;
+    font-size: 1.1rem;
     font-weight: 700;
     letter-spacing: -0.01em;
-    background: linear-gradient(
-        120deg,
-        var(--lp-accent-strong),
-        var(--lp-indigo)
-    );
-    -webkit-background-clip: text;
-    background-clip: text;
-    color: transparent;
+    color: var(--lp-accent);
 }
 
 .lp-stat-label {
     margin: 0;
-    font-size: 0.94rem;
+    font-size: 0.9rem;
     line-height: 1.55;
 }
 
 .lp-hero-visual {
     position: relative;
-    min-height: 38rem;
-    animation: lp-rise 700ms ease both;
 }
 
 .lp-terminal {
-    position: absolute;
-    inset: 2rem 0 4rem 0;
     overflow: hidden;
-    border: 1px solid rgba(255, 255, 255, 0.07);
-    border-radius: 1.7rem;
-    background: linear-gradient(
-        180deg,
-        rgba(14, 26, 46, 0.98),
-        rgba(7, 14, 26, 0.99)
-    );
-    box-shadow:
-        0 40px 110px rgba(8, 15, 30, 0.42),
-        0 0 0 1px rgba(37, 99, 235, 0.12),
-        inset 0 1px 0 rgba(255, 255, 255, 0.05);
-}
-
-.dark .lp-terminal {
-    box-shadow:
-        0 40px 120px rgba(0, 0, 0, 0.55),
-        0 0 60px rgba(37, 99, 235, 0.16),
-        inset 0 1px 0 rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--lp-border);
+    border-radius: 12px;
+    background: var(--lp-terminal);
 }
 
 .lp-terminal-bar {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    padding: 0.95rem 1.1rem;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.07);
-    color: rgba(217, 227, 244, 0.8);
-    font-size: 0.88rem;
+    padding: 0.9rem 1.1rem;
+    border-bottom: 1px solid var(--lp-border);
+    color: var(--lp-text-faint);
+    font-size: 0.85rem;
 }
 
 .lp-terminal-bar span {
     display: inline-block;
-    width: 0.72rem;
-    height: 0.72rem;
+    width: 0.7rem;
+    height: 0.7rem;
     border-radius: 50%;
-    background: var(--lp-accent);
-}
-
-.lp-terminal-bar span:nth-child(2) {
-    background: var(--lp-indigo);
-}
-
-.lp-terminal-bar span:nth-child(3) {
-    background: var(--lp-teal);
+    background: var(--lp-border-strong);
 }
 
 .lp-terminal-bar strong {
     margin-left: 0.5rem;
     font-weight: 600;
     letter-spacing: 0.01em;
+    color: var(--lp-text-muted);
 }
 
 .lp-terminal-body {
     margin: 0;
-    padding: 1.35rem 1.4rem 1.6rem;
+    padding: 1.4rem 1.5rem 1.6rem;
     color: var(--lp-terminal-text);
     font-family: var(--lp-font-mono);
-    font-size: 0.88rem;
-    line-height: 1.85;
+    font-size: 0.86rem;
+    line-height: 1.9;
     white-space: pre-wrap;
 }
 
@@ -464,23 +347,22 @@
 }
 
 .lp-terminal-prompt {
-    color: #7dd3fc;
+    color: var(--lp-text-faint);
     font-weight: 700;
 }
 
 .lp-terminal-line-success {
-    color: #86efac;
+    color: #4ade80;
 }
 
 .lp-terminal-line-header {
     color: #93c5fd;
-    opacity: 0.94;
 }
 
 .lp-terminal-line-table,
 .lp-terminal-line-metrics,
 .lp-terminal-line-output {
-    color: rgba(217, 227, 244, 0.88);
+    color: var(--lp-text-muted);
 }
 
 .lp-code-inline,
@@ -499,93 +381,39 @@
 }
 
 .lp-code-placeholder {
-    color: #fca5a5;
+    color: #f87171;
 }
 
-.dark .lp-code-placeholder {
-    color: #fda4af;
-}
-
-.lp-floating-card {
-    position: absolute;
-    border-radius: 1.4rem;
-    padding: 1rem 1.1rem;
-}
-
-.lp-floating-card-queue {
-    top: 0.2rem;
-    right: -0.6rem;
-    width: 15rem;
-    animation: lp-float 5.5s ease-in-out infinite;
-}
-
-.lp-floating-card-gpu {
-    bottom: 1.4rem;
-    left: -0.75rem;
-    width: 13rem;
-    animation: lp-float 6.3s ease-in-out infinite;
-}
-
-.lp-floating-title,
 .lp-compare-label {
-    margin: 0 0 0.85rem;
-    font-size: 0.76rem;
-    font-weight: 700;
-    letter-spacing: 0.13em;
+    margin: 0 0 1rem;
+    font-size: 0.78rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
     text-transform: uppercase;
-    color: var(--lp-accent-strong);
-}
-
-.lp-floating-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.85rem;
-}
-
-.lp-floating-grid div,
-.lp-floating-stack div {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.lp-floating-grid span,
-.lp-floating-stack span {
-    color: var(--lp-text-muted);
-    font-size: 0.8rem;
-}
-
-.lp-floating-grid strong,
-.lp-floating-stack strong {
-    font-size: 1.02rem;
-    font-family: var(--lp-font-mono);
-}
-
-.lp-floating-stack {
-    display: grid;
-    gap: 0.8rem;
+    color: var(--lp-text-faint);
 }
 
 .lp-section {
-    padding: 2rem 0 0;
+    padding: 0;
 }
 
 .lp-section + .lp-section {
-    margin-top: 3.4rem;
+    margin-top: 4.5rem;
 }
 
 .lp-section-heading {
-    max-width: 44rem;
-    margin-bottom: 1.9rem;
+    max-width: 42rem;
+    margin-bottom: 2rem;
 }
 
 .lp-section-heading h2,
 .lp-closing h2 {
     margin: 0;
-    font-size: clamp(1.9rem, 4vw, 3.2rem);
-    line-height: 1.05;
-    letter-spacing: -0.035em;
+    font-size: clamp(1.8rem, 3.4vw, 2.6rem);
+    line-height: 1.1;
+    letter-spacing: -0.03em;
     font-weight: 700;
+    color: var(--lp-text);
 }
 
 .lp-section-heading p {
@@ -595,38 +423,24 @@
 .lp-compare {
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1.1rem;
+    gap: 1rem;
 }
 
 .lp-compare-card {
-    padding: 1.5rem;
-    border-radius: 1.5rem;
+    padding: 1.5rem 1.6rem;
 }
 
 .lp-compare-card-accent {
-    border-color: color-mix(
-        in srgb,
-        var(--lp-accent) 28%,
-        var(--lp-border)
-    );
-    background: linear-gradient(
-        180deg,
-        color-mix(
-            in srgb,
-            var(--lp-accent-soft) 70%,
-            var(--lp-bg-elevated) 30%
-        ),
-        color-mix(in srgb, var(--lp-bg-elevated) 94%, transparent)
-    );
+    background: var(--lp-accent-soft);
 }
 
 .lp-compare-card ul {
     margin: 0;
-    padding-left: 1.15rem;
+    padding-left: 1.1rem;
 }
 
 .lp-compare-card li {
-    margin-top: 0.55rem;
+    margin-top: 0.6rem;
 }
 
 .lp-compare-card li::marker {
@@ -637,26 +451,22 @@
 .lp-card-grid {
     display: grid;
     grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1.1rem;
+    gap: 1rem;
 }
 
 .lp-step-card,
 .lp-card {
     padding: 1.4rem;
-    border-radius: 1.5rem;
 }
 
 .lp-step-label {
     display: inline-flex;
     align-items: center;
     margin-bottom: 1.1rem;
-    padding: 0.18rem 0.6rem;
-    border-radius: 0.55rem;
-    background: var(--lp-accent-soft);
-    color: var(--lp-accent-strong);
-    font-size: 0.82rem;
+    font-size: 0.78rem;
     font-weight: 600;
-    letter-spacing: 0.06em;
+    letter-spacing: 0.04em;
+    color: var(--lp-text-faint);
 }
 
 .lp-step-card code,
@@ -665,16 +475,17 @@
 }
 
 .lp-step-card code {
-    display: flex;
-    align-items: center;
-    min-height: 3.5em;
-    padding: 0.6rem 0.8rem;
-    border-radius: 0.85rem;
+    display: block;
+    padding: 0.65rem 0.8rem;
+    border: 1px solid var(--lp-border);
+    border-radius: 8px;
     background: var(--lp-terminal);
     color: var(--lp-terminal-text);
     font-size: 0.85rem;
     line-height: 1.5;
-    overflow-x: auto;
+    white-space: pre-wrap;
+    overflow-wrap: break-word;
+    min-height: 3.9rem;
 }
 
 .lp-code-inline {
@@ -683,30 +494,20 @@
 
 .lp-step-card p,
 .lp-card p {
-    margin: 1.05rem 0 0;
+    margin: 1.1rem 0 0;
 }
 
 .lp-card h3 {
     margin: 0;
-    font-size: 1.16rem;
-    line-height: 1.28;
+    font-size: 1.08rem;
+    line-height: 1.3;
     letter-spacing: -0.01em;
+    color: var(--lp-text);
 }
 
-.lp-card-grid-scenarios {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
+.lp-card-grid-scenarios,
 .lp-card-grid-caps {
     grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.lp-card-scenario {
-    background: linear-gradient(
-        180deg,
-        color-mix(in srgb, var(--lp-bg-elevated) 95%, transparent),
-        color-mix(in srgb, var(--lp-accent-soft) 34%, transparent)
-    );
 }
 
 .lp-card-link a {
@@ -714,14 +515,15 @@
     align-items: center;
     gap: 0.35rem;
     margin-top: 1.1rem;
-    color: var(--lp-accent-strong);
+    color: var(--lp-accent);
     font-weight: 600;
+    font-size: 0.95rem;
     text-decoration: none;
-    transition: gap 180ms ease, color 180ms ease;
+    transition: color 140ms ease;
 }
 
 .lp-card-link a:hover {
-    gap: 0.55rem;
+    color: var(--lp-accent-hover);
 }
 
 .lp-card-link a::after {
@@ -730,20 +532,10 @@
 }
 
 .lp-mcp-callout {
-    margin-top: 1.5rem;
     padding: 2rem;
-    border: 1px solid color-mix(
-        in srgb,
-        var(--lp-accent) 24%,
-        var(--lp-border)
-    );
-    border-radius: 1.9rem;
-    background: linear-gradient(
-        135deg,
-        color-mix(in srgb, var(--lp-accent-soft) 44%, transparent),
-        color-mix(in srgb, var(--lp-bg-elevated) 92%, transparent)
-    );
-    box-shadow: var(--lp-shadow);
+    border: 1px solid var(--lp-border);
+    border-radius: 12px;
+    background: var(--lp-surface);
 }
 
 .lp-mcp-row {
@@ -751,13 +543,14 @@
     flex-wrap: wrap;
     align-items: center;
     gap: 1rem;
-    margin-top: 1.35rem;
+    margin-top: 1.5rem;
 }
 
 .lp-mcp-row pre {
     margin: 0;
-    padding: 0.95rem 1.2rem;
-    border-radius: 1rem;
+    padding: 0.9rem 1.1rem;
+    border: 1px solid var(--lp-border);
+    border-radius: 8px;
     background: var(--lp-terminal);
     color: var(--lp-terminal-text);
     overflow-x: auto;
@@ -769,23 +562,21 @@
 }
 
 .lp-closing {
-    margin-top: 3rem;
-    padding: 3rem 2rem;
-    border-radius: 2rem;
+    margin-top: 4.5rem;
+    padding: 3.5rem 2rem;
+    border: 1px solid var(--lp-border);
+    border-radius: 12px;
     text-align: center;
-    background:
-        radial-gradient(circle at top, rgba(37, 99, 235, 0.16), transparent 70%),
-        radial-gradient(circle at bottom right, rgba(79, 70, 229, 0.14), transparent 60%),
-        color-mix(in srgb, var(--lp-bg-elevated) 95%, transparent);
+    background: var(--lp-surface);
 }
 
 .lp-closing h2 {
-    max-width: 20ch;
+    max-width: 22ch;
     margin: 0 auto;
 }
 
 .lp-closing p {
-    max-width: 42rem;
+    max-width: 40rem;
     margin: 1rem auto 0;
 }
 
@@ -794,44 +585,12 @@
     margin: 2rem 0 0;
 }
 
-@keyframes lp-rise {
-    from {
-        opacity: 0;
-        transform: translateY(18px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-@keyframes lp-float {
-    0%,
-    100% {
-        transform: translateY(0);
-    }
-    50% {
-        transform: translateY(-10px);
-    }
-}
-
-@media (prefers-reduced-motion: reduce) {
-    .lp-hero-visual,
-    .lp-floating-card-queue,
-    .lp-floating-card-gpu {
-        animation: none;
-    }
-}
-
 @media (max-width: 1100px) {
     .lp-hero {
         grid-template-columns: 1fr;
+        gap: 2.5rem;
         min-height: auto;
         padding-top: 1rem;
-    }
-
-    .lp-hero-visual {
-        min-height: 34rem;
     }
 
     .lp-step-grid,
@@ -847,33 +606,15 @@
 
 @media (max-width: 760px) {
     .landing-page {
-        padding-top: 1.5rem;
+        padding: 2.5rem 0 4rem;
     }
 
     .landing-page section {
-        width: min(100vw - 1.5rem, 1180px);
+        width: min(100vw - 2rem, 1120px);
     }
 
     .lp-title {
-        font-size: clamp(2.4rem, 15vw, 3.8rem);
-    }
-
-    .lp-hero-visual {
-        min-height: 28rem;
-    }
-
-    .lp-terminal {
-        inset: 1rem 0 4rem;
-    }
-
-    .lp-floating-card-queue {
-        right: 0;
-        width: 12.5rem;
-    }
-
-    .lp-floating-card-gpu {
-        left: 0;
-        width: 11.5rem;
+        font-size: clamp(2.3rem, 13vw, 3.2rem);
     }
 
     .lp-compare,
@@ -886,6 +627,6 @@
 
     .lp-mcp-callout,
     .lp-closing {
-        padding: 1.5rem;
+        padding: 1.75rem;
     }
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -1,37 +1,41 @@
+/* ---- IBM Carbon / Swiss industrial design tokens ---- */
 :root {
     --lp-bg: #ffffff;
-    --lp-surface: #ffffff;
-    --lp-text: #0a0a0a;
-    --lp-text-muted: #52525b;
-    --lp-text-faint: #71717a;
-    --lp-border: #e4e4e7;
-    --lp-border-strong: #d4d4d8;
-    --lp-accent: #2563eb;
-    --lp-accent-hover: #1d4ed8;
-    --lp-accent-soft: #eff4ff;
-    --lp-terminal: #0a0a0a;
-    --lp-terminal-text: #e4e4e7;
-    --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
-    --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
+    --lp-text: #161616;
+    --lp-text-2: #525252;
+    --lp-text-3: #6f6f6f;
+    --lp-hairline: #e0e0e0;
+    --lp-hairline-2: #8d8d8d;
+    --lp-accent: #0f62fe;
+    --lp-accent-hover: #0353e9;
+    --lp-surface-2: #f4f4f4;
+    --lp-charcoal: #161616;
+    --lp-charcoal-text: #f4f4f4;
+    --lp-charcoal-text-2: #a8a8a8;
+    --lp-charcoal-hairline: #393939;
+    --lp-sans: "IBM Plex Sans", "Helvetica Neue", "Arial", sans-serif;
+    --lp-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
 
 .dark {
-    --lp-bg: #0a0a0a;
-    --lp-surface: #0a0a0a;
-    --lp-text: #ededed;
-    --lp-text-muted: #a1a1aa;
-    --lp-text-faint: #8b8b8b;
-    --lp-border: #262626;
-    --lp-border-strong: #3f3f46;
-    --lp-accent: #3b82f6;
-    --lp-accent-hover: #60a5fa;
-    --lp-accent-soft: #0f1a30;
-    --lp-terminal: #0a0a0a;
-    --lp-terminal-text: #e4e4e7;
-    --lp-font-display: "Space Grotesk", "Avenir Next", "Trebuchet MS", sans-serif;
-    --lp-font-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
+    --lp-bg: #161616;
+    --lp-text: #f4f4f4;
+    --lp-text-2: #c6c6c6;
+    --lp-text-3: #8d8d8d;
+    --lp-hairline: #393939;
+    --lp-hairline-2: #525252;
+    --lp-accent: #4589ff;
+    --lp-accent-hover: #78a9ff;
+    --lp-surface-2: #262626;
+    --lp-charcoal: #0f0f0f;
+    --lp-charcoal-text: #f4f4f4;
+    --lp-charcoal-text-2: #a8a8a8;
+    --lp-charcoal-hairline: #393939;
+    --lp-sans: "IBM Plex Sans", "Helvetica Neue", "Arial", sans-serif;
+    --lp-mono: "IBM Plex Mono", "SFMono-Regular", "Cascadia Code", monospace;
 }
 
+/* ---- shell: strip VitePress chrome, flat Carbon header ---- */
 .landing-page-shell .VPDoc {
     padding: 0;
 }
@@ -60,573 +64,704 @@
 }
 
 .landing-page-shell .VPNavBar {
+    height: 3rem;
     background: var(--lp-bg);
     backdrop-filter: none;
-    border-bottom: 1px solid var(--lp-border);
+    border-bottom: 1px solid var(--lp-hairline);
 }
 
+.landing-page-shell .VPNavBar .content {
+    height: 3rem;
+    font-family: var(--lp-sans);
+}
+
+.landing-page-shell .VPNavBar .search-box {
+    border-radius: 0;
+    border: 1px solid var(--lp-hairline);
+    background: var(--lp-bg);
+}
+
+.landing-page-shell .VPFooter {
+    background: var(--lp-bg);
+    border-top: 1px solid var(--lp-hairline);
+    font-family: var(--lp-sans);
+}
+
+.landing-page-shell .VPFooter .container {
+    max-width: 1440px;
+}
+
+/* ---- base ---- */
 .landing-page {
-    position: relative;
-    padding: 4rem 0 6rem;
     background: var(--lp-bg);
     color: var(--lp-text);
-    font-family: var(--lp-font-display);
+    font-family: var(--lp-sans);
+    font-size: 1rem;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
 }
 
-.landing-page section {
-    position: relative;
-    width: min(1120px, calc(100vw - 3rem));
-    margin: 0 auto;
+.lp-container {
+    width: min(1440px, 100%);
+    margin-inline: auto;
+    padding-inline: clamp(1.25rem, 4vw, 4rem);
 }
 
-/* ---------- typography system ---------- */
-.landing-page h1,
-.landing-page h2,
-.landing-page h3,
-.lp-stat-value,
-.lp-brand {
-    font-family: var(--lp-font-display);
-}
-
-.lp-terminal-body,
-.lp-terminal-line-command,
-.lp-code-inline,
-.lp-step-card code,
-.lp-mcp-row code,
-.lp-step-label {
-    font-family: var(--lp-font-mono);
-}
-
-.lp-hero {
-    display: grid;
-    grid-template-columns: minmax(0, 1.05fr) minmax(320px, 0.95fr);
-    gap: 4rem;
-    align-items: center;
-    min-height: calc(100vh - 12rem);
-    padding: 2rem 0 4rem;
-}
-
-.lp-brand {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.6rem;
-    margin-bottom: 1.75rem;
-    font-size: 1.05rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
-}
-
-.lp-brand-logo {
-    width: 1.5rem;
-    height: 1.5rem;
-}
-
-.lp-eyebrow {
+/* ---- shared label ---- */
+.lp-label {
     display: flex;
     align-items: center;
-    gap: 0.6rem;
-    margin: 0 0 1.1rem;
-    color: var(--lp-text-faint);
-    font-size: 0.8rem;
-    font-weight: 600;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-}
-
-.lp-eyebrow::before {
-    content: "";
-    width: 1.4rem;
-    height: 2px;
-    background: var(--lp-accent);
-}
-
-.lp-title {
+    gap: 0.75rem;
     margin: 0;
-    font-size: clamp(2.7rem, 5.4vw, 4.6rem);
-    line-height: 1.02;
-    letter-spacing: -0.04em;
-    font-weight: 700;
-    color: var(--lp-text);
-    max-width: 15ch;
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--lp-text-2);
 }
 
-.lp-lead,
-.lp-section-heading p,
-.lp-card p,
-.lp-step-card p,
-.lp-closing p,
-.lp-stat-label,
-.lp-compare-card li {
-    color: var(--lp-text-muted);
-    font-size: 1.03rem;
-    line-height: 1.7;
-    font-family: var(--vp-font-family-base, "Inter", sans-serif);
+.lp-label-tick {
+    width: 0.75rem;
+    height: 0.75rem;
+    background: var(--lp-accent);
+    flex: none;
 }
 
-.lp-lead {
-    max-width: 42rem;
-    margin: 1.5rem 0 0;
-    font-size: 1.12rem;
+.lp-label-inv {
+    color: var(--lp-charcoal-text-2);
 }
 
-.lp-actions {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.8rem;
-    margin: 2.2rem 0 0;
-}
-
-.lp-button {
+/* ---- buttons ---- */
+.lp-btn,
+.lp-btn-text {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    min-height: 2.9rem;
-    padding: 0 1.2rem;
+    gap: 0.5rem;
+    min-height: 3.5rem;
     border: 1px solid transparent;
-    border-radius: 8px;
+    border-radius: 0;
+    font-family: var(--lp-sans);
+    font-size: 1rem;
+    line-height: 1;
     text-decoration: none;
-    font-weight: 600;
-    font-size: 0.96rem;
-    font-family: var(--lp-font-display);
+    cursor: pointer;
     transition:
-        background-color 140ms ease,
-        border-color 140ms ease,
-        color 140ms ease;
+        background-color 100ms ease,
+        color 100ms ease,
+        border-color 100ms ease;
 }
 
-.lp-button-brand {
+.lp-btn {
+    padding: 0 1.75rem;
+}
+
+.lp-btn-primary,
+.lp-btn-inv {
     background: var(--lp-accent);
     color: #ffffff;
 }
 
-.lp-button-brand:hover {
+.lp-btn-primary:hover,
+.lp-btn-inv:hover {
     background: var(--lp-accent-hover);
 }
 
-.lp-button-alt {
-    background: var(--lp-surface);
-    border-color: var(--lp-border-strong);
-    color: var(--lp-text);
+.lp-btn-onblue {
+    background: #ffffff;
+    color: #0f62fe;
 }
 
-.lp-button-alt:hover {
-    border-color: var(--lp-text-faint);
+.lp-btn-onblue:hover {
+    background: #e0e0e0;
 }
 
-.lp-button-ghost {
-    color: var(--lp-text-muted);
-    border-color: transparent;
+.lp-btn-text {
+    padding: 0 0.25rem;
     background: transparent;
-    margin-left: 0.3rem;
-}
-
-.lp-button-ghost:hover {
-    color: var(--lp-text);
-}
-
-.lp-trust {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.6rem 1.6rem;
-    padding: 0;
-    margin: 2rem 0 0;
-    list-style: none;
-}
-
-.lp-trust li {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    font-size: 0.9rem;
-    color: var(--lp-text-muted);
-    font-family: var(--vp-font-family-base, "Inter", sans-serif);
-}
-
-.lp-trust li::before {
-    content: "";
-    width: 0.42rem;
-    height: 0.42rem;
-    border-radius: 50%;
-    background: var(--lp-accent);
-}
-
-.lp-stats {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 1rem;
-    margin-top: 2.5rem;
-}
-
-.lp-stat-card,
-.lp-compare-card,
-.lp-step-card,
-.lp-card {
-    border: 1px solid var(--lp-border);
-    background: var(--lp-surface);
-    border-radius: 10px;
-}
-
-.lp-stat-card:hover,
-.lp-compare-card:hover,
-.lp-step-card:hover,
-.lp-card:hover {
-    border-color: var(--lp-border-strong);
-}
-
-.lp-stat-card {
-    padding: 1.3rem 1.4rem;
-}
-
-.lp-stat-value {
-    margin: 0 0 0.4rem;
-    font-size: 1.1rem;
-    font-weight: 700;
-    letter-spacing: -0.01em;
     color: var(--lp-accent);
 }
 
-.lp-stat-label {
-    margin: 0;
-    font-size: 0.9rem;
-    line-height: 1.55;
-}
-
-.lp-hero-visual {
-    position: relative;
-}
-
-.lp-terminal {
-    overflow: hidden;
-    border: 1px solid var(--lp-border);
-    border-radius: 12px;
-    background: var(--lp-terminal);
-}
-
-.lp-terminal-bar {
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    padding: 0.9rem 1.1rem;
-    border-bottom: 1px solid var(--lp-border);
-    color: var(--lp-text-faint);
-    font-size: 0.85rem;
-}
-
-.lp-terminal-bar span {
-    display: inline-block;
-    width: 0.7rem;
-    height: 0.7rem;
-    border-radius: 50%;
-    background: var(--lp-border-strong);
-}
-
-.lp-terminal-bar strong {
-    margin-left: 0.5rem;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    color: var(--lp-text-muted);
-}
-
-.lp-terminal-body {
-    margin: 0;
-    padding: 1.4rem 1.5rem 1.6rem;
-    color: var(--lp-terminal-text);
-    font-family: var(--lp-font-mono);
-    font-size: 0.86rem;
-    line-height: 1.9;
-    white-space: pre-wrap;
-}
-
-.lp-terminal-line {
-    white-space: pre-wrap;
-}
-
-.lp-terminal-line + .lp-terminal-line {
-    margin-top: 0.05rem;
-}
-
-.lp-terminal-prompt {
-    color: var(--lp-text-faint);
-    font-weight: 700;
-}
-
-.lp-terminal-line-success {
-    color: #4ade80;
-}
-
-.lp-terminal-line-header {
-    color: #93c5fd;
-}
-
-.lp-terminal-line-table,
-.lp-terminal-line-metrics,
-.lp-terminal-line-output {
-    color: var(--lp-text-muted);
-}
-
-.lp-code-inline,
-.lp-terminal-line-command {
-    font-family: var(--lp-font-mono);
-}
-
-.lp-code-inline span[style],
-.lp-terminal-line-command span[style] {
-    color: var(--shiki-light) !important;
-}
-
-.dark .lp-code-inline span[style],
-.dark .lp-terminal-line-command span[style] {
-    color: var(--shiki-dark) !important;
-}
-
-.lp-code-placeholder {
-    color: #f87171;
-}
-
-.lp-compare-label {
-    margin: 0 0 1rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-    color: var(--lp-text-faint);
-}
-
-.lp-section {
-    padding: 0;
-}
-
-.lp-section + .lp-section {
-    margin-top: 4.5rem;
-}
-
-.lp-section-heading {
-    max-width: 42rem;
-    margin-bottom: 2rem;
-}
-
-.lp-section-heading h2,
-.lp-closing h2 {
-    margin: 0;
-    font-size: clamp(1.8rem, 3.4vw, 2.6rem);
-    line-height: 1.1;
-    letter-spacing: -0.03em;
-    font-weight: 700;
-    color: var(--lp-text);
-}
-
-.lp-section-heading p {
-    margin: 1rem 0 0;
-}
-
-.lp-compare {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 1rem;
-}
-
-.lp-compare-card {
-    padding: 1.5rem 1.6rem;
-}
-
-.lp-compare-card-accent {
-    background: var(--lp-accent-soft);
-}
-
-.lp-compare-card ul {
-    margin: 0;
-    padding-left: 1.1rem;
-}
-
-.lp-compare-card li {
-    margin-top: 0.6rem;
-}
-
-.lp-compare-card li::marker {
-    color: var(--lp-accent);
-}
-
-.lp-step-grid,
-.lp-card-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 1rem;
-}
-
-.lp-step-card,
-.lp-card {
-    padding: 1.4rem;
-}
-
-.lp-step-label {
-    display: inline-flex;
-    align-items: center;
-    margin-bottom: 1.1rem;
-    font-size: 0.78rem;
-    font-weight: 600;
-    letter-spacing: 0.04em;
-    color: var(--lp-text-faint);
-}
-
-.lp-step-card code,
-.lp-mcp-row code {
-    font-family: var(--lp-font-mono);
-}
-
-.lp-step-card code {
-    display: block;
-    padding: 0.65rem 0.8rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 8px;
-    background: var(--lp-terminal);
-    color: var(--lp-terminal-text);
-    font-size: 0.85rem;
-    line-height: 1.5;
-    white-space: pre-wrap;
-    overflow-wrap: break-word;
-    min-height: 3.9rem;
-}
-
-.lp-code-inline {
-    white-space: pre-wrap;
-}
-
-.lp-step-card p,
-.lp-card p {
-    margin: 1.1rem 0 0;
-}
-
-.lp-card h3 {
-    margin: 0;
-    font-size: 1.08rem;
-    line-height: 1.3;
-    letter-spacing: -0.01em;
-    color: var(--lp-text);
-}
-
-.lp-card-grid-scenarios,
-.lp-card-grid-caps {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
-.lp-card-link a {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.35rem;
-    margin-top: 1.1rem;
-    color: var(--lp-accent);
-    font-weight: 600;
-    font-size: 0.95rem;
-    text-decoration: none;
-    transition: color 140ms ease;
-}
-
-.lp-card-link a:hover {
+.lp-btn-text:hover {
     color: var(--lp-accent-hover);
 }
 
-.lp-card-link a::after {
-    content: "→";
-    font-family: var(--lp-font-mono);
+.lp-btn-text-inv {
+    color: #ffffff;
 }
 
-.lp-mcp-callout {
-    padding: 2rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 12px;
-    background: var(--lp-surface);
+.lp-btn-text-inv:hover {
+    color: #c6c6c6;
 }
 
-.lp-mcp-row {
+.lp-arrow {
+    font-family: var(--lp-mono);
+    font-size: 1rem;
+    line-height: 1;
+    transition: transform 100ms ease;
+}
+
+a:hover .lp-arrow {
+    transform: translateX(3px);
+}
+
+/* ---- hero ---- */
+.lp-hero {
+    padding-top: clamp(4rem, 11vw, 8rem);
+}
+
+.lp-hero .lp-label {
+    margin-bottom: 2.25rem;
+}
+
+.lp-hero-title {
+    margin: 0;
+    font-size: clamp(2.75rem, 8.5vw, 6.25rem);
+    line-height: 1.0;
+    letter-spacing: -0.04em;
+    font-weight: 600;
+    color: var(--lp-text);
+    max-width: 19ch;
+}
+
+.lp-hero-lead {
+    margin: 2rem 0 0;
+    font-size: clamp(1.125rem, 2vw, 1.5rem);
+    line-height: 1.5;
+    font-weight: 300;
+    color: var(--lp-text-2);
+    max-width: 46ch;
+}
+
+.lp-hero-actions {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 1rem;
-    margin-top: 1.5rem;
+    gap: 1.75rem;
+    margin-top: 3rem;
 }
 
-.lp-mcp-row pre {
+/* ---- spec strip ---- */
+.lp-specstrip {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    list-style: none;
+    margin: 4rem 0 0;
+    padding: 0;
+    border-top: 1px solid var(--lp-hairline);
+}
+
+.lp-spec {
+    display: flex;
+    align-items: baseline;
+    gap: 0.85rem;
+    padding: 1.6rem 1.75rem 1.75rem 0;
+    border-right: 1px solid var(--lp-hairline);
+}
+
+.lp-spec:last-child {
+    border-right: none;
+    padding-right: 0;
+}
+
+.lp-spec + .lp-spec {
+    padding-left: 1.75rem;
+}
+
+.lp-spec-idx {
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    letter-spacing: 0.1em;
+    color: var(--lp-accent);
+    flex: none;
+}
+
+.lp-spec-text {
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    color: var(--lp-text-2);
+}
+
+/* ---- sections ---- */
+.lp-section {
+    border-top: 1px solid var(--lp-hairline);
+    padding-block: clamp(3.5rem, 8vw, 6rem);
+}
+
+.lp-sec-head {
+    max-width: 62ch;
+    margin-bottom: 3rem;
+}
+
+.lp-sec-eyebrow {
+    display: flex;
+    align-items: center;
+    gap: 0.85rem;
+    margin: 0 0 1.4rem;
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--lp-text-3);
+}
+
+.lp-sec-idx {
+    color: var(--lp-accent);
+}
+
+.lp-sec-title {
     margin: 0;
-    padding: 0.9rem 1.1rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 8px;
-    background: var(--lp-terminal);
-    color: var(--lp-terminal-text);
+    font-size: clamp(1.875rem, 4vw, 3.25rem);
+    line-height: 1.06;
+    letter-spacing: -0.03em;
+    font-weight: 600;
+    color: var(--lp-text);
+}
+
+.lp-sec-lead {
+    margin: 1.4rem 0 0;
+    font-size: 1.125rem;
+    line-height: 1.6;
+    color: var(--lp-text-2);
+    max-width: 52ch;
+}
+
+/* ---- terminal ---- */
+.lp-terminal {
+    background: var(--lp-charcoal);
+    color: var(--lp-charcoal-text);
+}
+
+.lp-terminal-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.9rem 1.75rem;
+    border-bottom: 1px solid var(--lp-charcoal-hairline);
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    letter-spacing: 0.04em;
+    color: var(--lp-charcoal-text-2);
+}
+
+.lp-terminal-meta {
+    opacity: 0.65;
+    white-space: nowrap;
+}
+
+.lp-terminal-body {
+    padding: 1.9rem 1.75rem 2.25rem;
+    font-family: var(--lp-mono);
+    font-size: 0.9rem;
+    line-height: 2.05;
     overflow-x: auto;
 }
 
-.lp-mcp-row pre .lp-code-inline {
+.lp-tl {
+    white-space: pre;
+    color: var(--lp-charcoal-text-2);
+}
+
+.lp-tl-command {
+    color: var(--lp-charcoal-text);
+}
+
+.lp-terminal-prompt {
+    color: var(--lp-accent);
+    font-weight: 600;
+}
+
+.lp-tl-success {
+    color: #4ade80;
+}
+
+.lp-tl-header {
+    color: var(--lp-charcoal-text-2);
+    opacity: 0.85;
+}
+
+.lp-tl-metrics {
+    color: var(--lp-charcoal-text);
+}
+
+/* force single colour for shiki tokens inside the always-dark terminal */
+.lp-terminal-body span[style] {
+    color: var(--lp-charcoal-text) !important;
+}
+
+/* ---- grid of cells (1px hairline separators) ---- */
+.lp-grid {
+    display: grid;
+    gap: 1px;
+    background: var(--lp-hairline);
+    border: 1px solid var(--lp-hairline);
+}
+
+.lp-grid-2 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.lp-grid-3 {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.lp-grid-4 {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.lp-cell {
+    background: var(--lp-bg);
+    padding: 2rem;
+    transition: background-color 100ms ease;
+}
+
+.lp-cell:hover {
+    background: var(--lp-surface-2);
+}
+
+.lp-cell-idx {
+    display: block;
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    letter-spacing: 0.1em;
+    color: var(--lp-accent);
+    margin-bottom: 1.75rem;
+}
+
+.lp-cell-title {
+    margin: 0;
+    font-size: 1.125rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    font-weight: 500;
+    color: var(--lp-text);
+}
+
+.lp-cell-body {
+    margin: 0.75rem 0 0;
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--lp-text-2);
+}
+
+.lp-cell-label {
+    margin: 0 0 1.5rem;
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+}
+
+.lp-cell-label-dim {
+    color: var(--lp-text-3);
+}
+
+.lp-cell-label-accent {
+    color: var(--lp-accent);
+}
+
+/* comparison lists with +/- markers */
+.lp-list {
+    list-style: none;
+    margin: 0;
     padding: 0;
-    background: transparent;
 }
 
+.lp-list li {
+    position: relative;
+    padding-left: 1.75rem;
+    margin-top: 1rem;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--lp-text-2);
+}
+
+.lp-list li:first-child {
+    margin-top: 0;
+}
+
+.lp-list li::before {
+    position: absolute;
+    left: 0;
+    top: 0;
+    font-family: var(--lp-mono);
+    font-size: 1rem;
+    line-height: 1.6;
+}
+
+.lp-list-minus li::before {
+    content: "−";
+    color: var(--lp-text-3);
+}
+
+.lp-list-plus li::before {
+    content: "+";
+    color: var(--lp-accent);
+}
+
+/* how-it-works steps */
+.lp-step-cmd {
+    display: block;
+    font-family: var(--lp-mono);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    color: var(--lp-text);
+    margin-bottom: 1.25rem;
+    word-break: break-word;
+}
+
+.lp-step-cmd span[style] {
+    color: var(--lp-text) !important;
+}
+
+.lp-code-placeholder {
+    color: var(--lp-text-3);
+}
+
+.lp-step-desc {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--lp-text-2);
+}
+
+/* ---- documentation table ---- */
+.lp-table {
+    border-top: 1px solid var(--lp-hairline);
+}
+
+.lp-table-row {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1.7fr) auto;
+    align-items: baseline;
+    gap: 2rem;
+    padding: 1.75rem 0;
+    border-bottom: 1px solid var(--lp-hairline);
+    text-decoration: none;
+    transition: background-color 100ms ease;
+}
+
+.lp-table-row:hover {
+    background: var(--lp-surface-2);
+}
+
+.lp-table-title {
+    font-size: 1.125rem;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+    font-weight: 500;
+    color: var(--lp-text);
+}
+
+.lp-table-body {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--lp-text-2);
+}
+
+.lp-table-cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--lp-mono);
+    font-size: 0.875rem;
+    letter-spacing: 0.04em;
+    color: var(--lp-accent);
+    white-space: nowrap;
+}
+
+/* ---- MCP band ---- */
+.lp-band {
+    border-top: 1px solid var(--lp-hairline);
+    background: var(--lp-charcoal);
+    color: var(--lp-charcoal-text);
+}
+
+.lp-band-inner {
+    display: grid;
+    grid-template-columns: minmax(0, 1.5fr) minmax(0, 1fr);
+    gap: 3rem;
+    align-items: center;
+    padding-block: clamp(3.5rem, 8vw, 5.5rem);
+}
+
+.lp-band-title {
+    margin: 0;
+    font-size: clamp(1.875rem, 3.6vw, 2.75rem);
+    line-height: 1.1;
+    letter-spacing: -0.025em;
+    font-weight: 600;
+    color: var(--lp-charcoal-text);
+    max-width: 20ch;
+}
+
+.lp-band-lead {
+    margin: 1.4rem 0 0;
+    font-size: 1.0625rem;
+    line-height: 1.6;
+    color: var(--lp-charcoal-text-2);
+    max-width: 44ch;
+}
+
+.lp-band-action {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 1.5rem;
+}
+
+.lp-band-cmd {
+    margin: 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--lp-charcoal-hairline);
+    background: #000000;
+    font-family: var(--lp-mono);
+    font-size: 1rem;
+    color: var(--lp-charcoal-text);
+    overflow-x: auto;
+}
+
+.lp-band-cmd span[style] {
+    color: var(--lp-charcoal-text) !important;
+}
+
+.lp-band-cmd .lp-code-placeholder {
+    color: var(--lp-accent);
+}
+
+/* ---- closing (solid IBM Blue) ---- */
 .lp-closing {
-    margin-top: 4.5rem;
-    padding: 3.5rem 2rem;
-    border: 1px solid var(--lp-border);
-    border-radius: 12px;
-    text-align: center;
-    background: var(--lp-surface);
+    border-top: 1px solid var(--lp-hairline);
+    background: #0f62fe;
+    color: #ffffff;
 }
 
-.lp-closing h2 {
-    max-width: 22ch;
-    margin: 0 auto;
+.lp-closing .lp-container {
+    padding-block: clamp(4rem, 10vw, 7rem);
 }
 
-.lp-closing p {
-    max-width: 40rem;
-    margin: 1rem auto 0;
+.lp-closing-title {
+    margin: 0;
+    font-size: clamp(2.25rem, 6vw, 4.5rem);
+    line-height: 1.0;
+    letter-spacing: -0.035em;
+    font-weight: 600;
+    color: #ffffff;
+    max-width: 18ch;
 }
 
-.lp-closing .lp-actions {
-    justify-content: center;
-    margin: 2rem 0 0;
+.lp-closing-lead {
+    margin: 1.6rem 0 0;
+    font-size: 1.25rem;
+    line-height: 1.5;
+    color: rgba(255, 255, 255, 0.78);
+    max-width: 40ch;
 }
 
+.lp-closing .lp-hero-actions {
+    margin-top: 2.75rem;
+}
+
+/* ---- responsive ---- */
 @media (max-width: 1100px) {
-    .lp-hero {
-        grid-template-columns: 1fr;
-        gap: 2.5rem;
-        min-height: auto;
-        padding-top: 1rem;
-    }
-
-    .lp-step-grid,
-    .lp-card-grid,
-    .lp-card-grid-caps {
+    .lp-specstrip {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
-    .lp-stats {
+    .lp-spec {
+        border-bottom: 1px solid var(--lp-hairline);
+    }
+
+    .lp-spec:nth-child(odd) {
+        padding-left: 0;
+    }
+
+    .lp-spec:nth-child(even) {
+        padding-left: 1.75rem;
+    }
+
+    .lp-spec:last-child,
+    .lp-spec:nth-last-child(2) {
+        border-bottom: none;
+    }
+
+    .lp-grid-4 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lp-grid-3 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .lp-band-inner {
         grid-template-columns: 1fr;
+        gap: 2.5rem;
+    }
+
+    .lp-table-row {
+        grid-template-columns: 1fr auto;
+    }
+
+    .lp-table-body {
+        grid-column: 1 / -1;
+        order: 3;
     }
 }
 
 @media (max-width: 760px) {
-    .landing-page {
-        padding: 2.5rem 0 4rem;
+    .lp-hero {
+        padding-top: 3rem;
     }
 
-    .landing-page section {
-        width: min(100vw - 2rem, 1120px);
+    .lp-hero-title {
+        font-size: clamp(2.4rem, 13vw, 3.5rem);
     }
 
-    .lp-title {
-        font-size: clamp(2.3rem, 13vw, 3.2rem);
+    .lp-hero-actions {
+        gap: 1.25rem 1.5rem;
     }
 
-    .lp-compare,
-    .lp-step-grid,
-    .lp-card-grid,
-    .lp-card-grid-scenarios,
-    .lp-card-grid-caps {
+    .lp-specstrip {
+        grid-template-columns: 1fr;
+        margin-top: 3rem;
+    }
+
+    .lp-spec {
+        border-bottom: 1px solid var(--lp-hairline);
+        padding-left: 0;
+    }
+
+    .lp-spec:last-child {
+        border-bottom: none;
+    }
+
+    .lp-grid-2,
+    .lp-grid-3,
+    .lp-grid-4 {
         grid-template-columns: 1fr;
     }
 
-    .lp-mcp-callout,
-    .lp-closing {
-        padding: 1.75rem;
+    .lp-sec-head {
+        margin-bottom: 2rem;
+    }
+
+    .lp-table-row {
+        grid-template-columns: 1fr;
+        gap: 0.5rem;
+    }
+
+    .lp-table-body {
+        order: 0;
+    }
+
+    .lp-table-cta {
+        order: 3;
     }
 }

--- a/docs/.vitepress/theme/style.css
+++ b/docs/.vitepress/theme/style.css
@@ -331,7 +331,7 @@ a:hover .lp-arrow {
     max-width: 52ch;
 }
 
-/* ---- terminal ---- */
+/* ---- terminal (animated session) ---- */
 .lp-terminal {
     background: var(--lp-charcoal);
     color: var(--lp-charcoal-text);
@@ -350,9 +350,24 @@ a:hover .lp-arrow {
     color: var(--lp-charcoal-text-2);
 }
 
+.lp-terminal-path {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.6rem;
+}
+
 .lp-terminal-meta {
     opacity: 0.65;
     white-space: nowrap;
+}
+
+.lp-live {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: #4ade80;
+    flex: none;
+    animation: lp-pulse 2s cubic-bezier(0.4, 0, 0.6, 1) infinite;
 }
 
 .lp-terminal-body {
@@ -361,38 +376,100 @@ a:hover .lp-arrow {
     font-size: 0.9rem;
     line-height: 2.05;
     overflow-x: auto;
+    min-height: 16.6rem;
 }
 
 .lp-tl {
     white-space: pre;
     color: var(--lp-charcoal-text-2);
+    animation: lp-tlin 240ms ease-out;
 }
 
-.lp-tl-command {
-    color: var(--lp-charcoal-text);
-}
-
-.lp-terminal-prompt {
+.lp-prompt {
     color: var(--lp-accent);
     font-weight: 600;
 }
 
-.lp-tl-success {
+.lp-cmd-text {
+    color: var(--lp-charcoal-text);
+}
+
+.lp-cursor {
+    display: inline-block;
+    width: 0.6ch;
+    height: 1.15em;
+    margin-left: 0.2ch;
+    vertical-align: -0.18em;
+    background: var(--lp-charcoal-text);
+    animation: lp-blink 1.06s steps(1) infinite;
+}
+
+.lp-tl-ok {
     color: #4ade80;
 }
 
-.lp-tl-header {
+.lp-tl-metric {
+    color: var(--lp-charcoal-text);
+}
+
+/* queue table (header + row) aligned on a mono grid */
+.lp-tl-thead,
+.lp-tl-trow {
+    display: grid;
+    grid-template-columns: 5ch 8ch 9ch 4ch 7ch;
+    gap: 0 0.5ch;
+    white-space: nowrap;
+}
+
+.lp-th {
+    color: var(--lp-charcoal-text-2);
+    opacity: 0.8;
+}
+
+.lp-td {
+    color: var(--lp-charcoal-text-2);
+}
+
+.lp-state {
+    font-weight: 600;
+}
+
+.lp-state.is-pend {
     color: var(--lp-charcoal-text-2);
     opacity: 0.85;
 }
 
-.lp-tl-metrics {
-    color: var(--lp-charcoal-text);
+.lp-state.is-run {
+    color: #4ade80;
 }
 
-/* force single colour for shiki tokens inside the always-dark terminal */
-.lp-terminal-body span[style] {
-    color: var(--lp-charcoal-text) !important;
+@keyframes lp-tlin {
+    from {
+        opacity: 0;
+        transform: translateY(3px);
+    }
+
+    to {
+        opacity: 1;
+        transform: none;
+    }
+}
+
+@keyframes lp-blink {
+    50% {
+        opacity: 0;
+    }
+}
+
+@keyframes lp-pulse {
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.35;
+    }
 }
 
 /* ---- grid of cells (1px hairline separators) ---- */
@@ -628,12 +705,8 @@ a:hover .lp-arrow {
     overflow-x: auto;
 }
 
-.lp-band-cmd span[style] {
-    color: var(--lp-charcoal-text) !important;
-}
-
-.lp-band-cmd .lp-code-placeholder {
-    color: var(--lp-accent);
+.lp-band-cmd-text {
+    color: var(--lp-charcoal-text);
 }
 
 /* ---- closing (solid IBM Blue) ---- */
@@ -696,6 +769,10 @@ a:hover .lp-arrow {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
 
+    .lp-flow {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
     .lp-grid-3 {
         grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -748,6 +825,10 @@ a:hover .lp-arrow {
         grid-template-columns: 1fr;
     }
 
+    .lp-flow {
+        grid-template-columns: 1fr;
+    }
+
     .lp-sec-head {
         margin-bottom: 2rem;
     }
@@ -763,5 +844,101 @@ a:hover .lp-arrow {
 
     .lp-table-cta {
         order: 3;
+    }
+}
+
+/* ---- how-it-works pipeline (animated sweep) ---- */
+.lp-flow {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1px;
+    background: var(--lp-hairline);
+    border: 1px solid var(--lp-hairline);
+}
+
+.lp-flow-stage {
+    position: relative;
+    background: var(--lp-bg);
+    padding: 1.9rem 1.75rem 2.1rem;
+    overflow: hidden;
+}
+
+.lp-flow-bar {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 2px;
+    background: var(--lp-accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    animation: lp-flowbar 4.2s cubic-bezier(0.4, 0, 0.2, 1) infinite;
+    animation-delay: calc(var(--i, 0) * 1.05s);
+}
+
+.lp-flow-idx {
+    display: block;
+    font-family: var(--lp-mono);
+    font-size: 0.8125rem;
+    letter-spacing: 0.1em;
+    color: var(--lp-text-3);
+    margin-bottom: 1.1rem;
+}
+
+.lp-flow-cmd {
+    display: block;
+    font-family: var(--lp-mono);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    color: var(--lp-text);
+    margin-bottom: 0.65rem;
+    overflow-wrap: break-word;
+}
+
+.lp-flow-label {
+    font-size: 0.9rem;
+    line-height: 1.5;
+    color: var(--lp-text-2);
+}
+
+@keyframes lp-flowbar {
+    0% {
+        transform: scaleX(0);
+        opacity: 1;
+    }
+
+    15% {
+        transform: scaleX(1);
+        opacity: 1;
+    }
+
+    25% {
+        transform: scaleX(1);
+        opacity: 1;
+    }
+
+    34% {
+        transform: scaleX(1);
+        opacity: 0;
+    }
+
+    100% {
+        transform: scaleX(1);
+        opacity: 0;
+    }
+}
+
+/* ---- reduced motion ---- */
+@media (prefers-reduced-motion: reduce) {
+    .lp-tl,
+    .lp-cursor,
+    .lp-live,
+    .lp-flow-bar {
+        animation: none !important;
+    }
+
+    .lp-flow-bar {
+        transform: scaleX(1);
+        opacity: 0.25;
     }
 }


### PR DESCRIPTION
Restyles the runqd.com landing page (the VitePress `docs/` homepage) for a more polished, on-brand look. Part of Multica issue **W-445**.

## What changed
- **Cohesive blue theme** — the palette now matches the `gflow` logo (blue/indigo on a clean light/dark neutral) instead of the previous cream/orange.
- **Real fonts** — the intended Space Grotesk (display) and IBM Plex Mono (code) fonts are now loaded and applied to headings and commands; previously they were referenced in CSS but never loaded, so they silently fell back to system fonts.
- **Layout polish** — section spacing, card hover states, gradient accent eyebrows/stat values, dot accents on trust pills, and a 3-column capabilities grid so desktop, mobile, and both locales stay balanced.

## Verification
Checked in a headless browser (Playwright/Chromium) across:
- Light + dark
- English + zh-CN
- Desktop (1440px) and mobile (390px)

No console errors. `vitepress build docs` succeeds.

Files: `docs/.vitepress/theme/style.css`, `docs/.vitepress/config.ts`, `docs/.vitepress/theme/components/LandingPage.vue`, `CHANGELOG.md`.